### PR TITLE
Improved handling of conditional and obsolete dependencies

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -168,7 +168,7 @@ def deptry(
 
 def log_obsolete_dependencies(dependencies: List[str], sep="\n\t") -> None:
     logging.info("\n-----------------------------------------------------\n")
-    logging.info(f"pyproject.toml contains obsolete dependencies:\n{sep}{sep.join(dependencies)}\n")
+    logging.info(f"pyproject.toml contains obsolete dependencies:\n{sep}{sep.join(sorted(dependencies))}\n")
     logging.info(
         """Consider removing them from your projects dependencies. If a package is used for development purposes, you should add
 it to your development dependencies instead."""
@@ -177,21 +177,23 @@ it to your development dependencies instead."""
 
 def log_missing_dependencies(dependencies: List[str], sep="\n\t") -> None:
     logging.info("\n-----------------------------------------------------\n")
-    logging.info(f"There are dependencies missing from pyproject.toml:\n{sep}{sep.join(dependencies)}\n")
+    logging.info(f"There are dependencies missing from pyproject.toml:\n{sep}{sep.join(sorted(dependencies))}\n")
     logging.info("""Consider adding them to your project's dependencies. """)
 
 
 def log_transitive_dependencies(dependencies: List[str], sep="\n\t") -> None:
     logging.info("\n-----------------------------------------------------\n")
     logging.info(
-        f"There are transitive dependencies that should be explicitly defined as dependencies in pyproject.toml:\n{sep}{sep.join(dependencies)}\n"
+        f"There are transitive dependencies that should be explicitly defined as dependencies in pyproject.toml:\n{sep}{sep.join(sorted(dependencies))}\n"
     )
     logging.info("""They are currently imported but not specified directly as your project's dependencies.""")
 
 
 def log_misplaced_develop_dependencies(dependencies: List[str], sep="\n\t") -> None:
     logging.info("\n-----------------------------------------------------\n")
-    logging.info(f"There are imported modules from development dependencies detected:\n{sep}{sep.join(dependencies)}\n")
+    logging.info(
+        f"There are imported modules from development dependencies detected:\n{sep}{sep.join(sorted(dependencies))}\n"
+    )
     logging.info(
         """Consider moving them to `[tool.poetry.dependencies]` in pyproject.toml. If this is not correct and the
 dependencies listed above are indeed development dependencies, it's likely that files were scanned that are only used

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -1,6 +1,7 @@
 import logging
 from pathlib import Path
 from typing import Dict, List
+from deptry.dependency import Dependency
 
 from deptry.dependency_getter import DependencyGetter
 from deptry.import_parser import ImportParser

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -1,7 +1,6 @@
 import logging
 from pathlib import Path
 from typing import Dict, List
-from deptry.dependency import Dependency
 
 from deptry.dependency_getter import DependencyGetter
 from deptry.import_parser import ImportParser

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -23,33 +23,33 @@ class Dependency:
         self.name = name
         self.is_conditional = conditional
         self.is_optional = optional
-        self.found = self.find(name)
+        self.found = self.find_metadata(name)
         self.top_levels = self._get_top_levels(name)
 
     def _get_top_levels(self, name: str) -> List[str]:
         top_levels = []
 
         if self.found:
-            metadata_top_levels = metadata.distribution(name).read_text("top_level.txt")
-            if metadata_top_levels:
-                top_levels +=[x for x in metadata_top_levels.split("\n") if len(x) > 0]
+            top_levels += self._get_top_level_module_names_from_metadata()
 
-        top_levels.append(name.replace('-','_').lower())
+        top_levels.append(name.replace("-", "_").lower())
         return set(top_levels)
 
     def __repr__(self) -> str:
         return f"Dependency '{self.name}'"
 
     def __str__(self) -> str:
-        return (
-            f"Dependency '{self.name}'{self._string_for_printing()}with top-levels: {self.top_levels}."
-        )
+        return f"Dependency '{self.name}'{self._string_for_printing()}with top-levels: {self.top_levels}."
 
-    def find(self, name):
+    def find_metadata(self, name):
         try:
             metadata.distribution(name)
+            return True
         except PackageNotFoundError:
-            logging.warning(f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its corresponding module name is '{name.replace('-','_').lower()}'.")
+            logging.warning(
+                f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its corresponding module name is '{name.replace('-','_').lower()}'."
+            )
+            return False
 
     def _string_for_printing(self):
         """
@@ -57,11 +57,18 @@ class Dependency:
         """
         output_list = []
         if self.is_optional:
-            output_list.append('optional')
+            output_list.append("optional")
         if self.is_conditional:
-            output_list.append('conditional')
+            output_list.append("conditional")
 
-        if len(output_list)>0:
+        if len(output_list) > 0:
             return f" ({', '.join(output_list)}) "
         else:
-            return ' '
+            return " "
+
+    def _get_top_level_module_names_from_metadata(self):
+        metadata_top_levels = metadata.distribution(self.name).read_text("top_level.txt")
+        if metadata_top_levels:
+            return [x for x in metadata_top_levels.split("\n") if len(x) > 0]
+        else:
+            return []

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -10,32 +10,58 @@ class Dependency:
     """
     A project's dependency with its associated top-level module names. There are stored in the metadata's top_level.txt.
     An example of this is 'matplotlib' with top-levels: ['matplotlib', 'mpl_toolkits', 'pylab'].
+
+    By default, we also add the dependency's name with '-' replaced by '_' to the top-level modules.
     """
 
-    def __init__(self, name: str, conditional: bool = False) -> None:
+    def __init__(self, name: str, conditional: bool = False, optional: bool = False) -> None:
         """
         Args:
             name: Name of the dependency, as shown in pyproject.toml
             conditional: boolean to indicate if the dependency is conditional, e.g. 'importlib-metadata': {'version': '*', 'python': '<=3.7'}
         """
         self.name = name
-        self.conditional = conditional
+        self.is_conditional = conditional
+        self.is_optional = optional
+        self.found = self.find(name)
         self.top_levels = self._get_top_levels(name)
 
-    @staticmethod
-    def _get_top_levels(name: str) -> List[str]:
-        try:
-            top_levels = metadata.distribution(name).read_text("top_level.txt")
-            if top_levels:
-                return [x for x in top_levels.split("\n") if len(x) > 0]
-        except PackageNotFoundError:
-            logging.warning(f"Warning: Package '{name}' not found in current environment.")
-            return None
+    def _get_top_levels(self, name: str) -> List[str]:
+        top_levels = []
+
+        if self.found:
+            metadata_top_levels = metadata.distribution(name).read_text("top_level.txt")
+            if metadata_top_levels:
+                top_levels +=[x for x in metadata_top_levels.split("\n") if len(x) > 0]
+
+        top_levels.append(name.replace('-','_').lower())
+        return set(top_levels)
 
     def __repr__(self) -> str:
         return f"Dependency '{self.name}'"
 
     def __str__(self) -> str:
         return (
-            f"{'Conditional d' if self.conditional else 'D'}ependency '{self.name}' with top-levels: {self.top_levels}."
+            f"Dependency '{self.name}'{self._string_for_printing()}with top-levels: {self.top_levels}."
         )
+
+    def find(self, name):
+        try:
+            metadata.distribution(name)
+        except PackageNotFoundError:
+            logging.warning(f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its corresponding module name is '{name.replace('-','_').lower()}'.")
+
+    def _string_for_printing(self):
+        """
+        Return 'Conditional', 'Optional' or 'Conditional and optional'
+        """
+        output_list = []
+        if self.is_optional:
+            output_list.append('optional')
+        if self.is_conditional:
+            output_list.append('conditional')
+
+        if len(output_list)>0:
+            return f" ({', '.join(output_list)}) "
+        else:
+            return ' '

--- a/deptry/dependency_getter.py
+++ b/deptry/dependency_getter.py
@@ -25,12 +25,19 @@ class DependencyGetter:
         dependencies = []
         for dep, spec in pyproject_toml_dependencies.items():
             if not dep == "python":
+
                 # if of the shape `tomli = { version = "^2.0.1", python = "<3.11" }`, mark as conditional.
+                conditional = False
                 if isinstance(spec, dict) and "python" in spec.keys() and "version" in spec.keys():
-                    dependencies.append(Dependency(dep, conditional=True))
-                else:
-                    dependencies.append(Dependency(dep))
-        dependencies.sort(key=lambda x: x.name)
+                    conditional = True
+                
+                # if of the shape `isodate = {version = "*", optional = true}` mark as optional`
+                optional = False
+                if isinstance(spec, dict) and "optional" in spec.keys() and spec["optional"]:
+                    optional = True
+                
+                dependencies.append(Dependency(dep, conditional=conditional, optional=optional))
+
         self._log_dependencies(dependencies)
         return dependencies
 

--- a/deptry/issue_finders/misplaced_dev.py
+++ b/deptry/issue_finders/misplaced_dev.py
@@ -30,7 +30,7 @@ class MisplacedDevDependenciesFinder:
         return dev_dependencies
 
     def _is_development_dependency(self, module: Module) -> bool:
-        if module.dev_dependency:
+        if module.is_dev_dependency:
             if module.name in self.ignore_misplaced_dev:
                 logging.debug(
                     f"Module '{module.package}' found to be a misplaced development dependency, but ignoring."

--- a/deptry/issue_finders/missing.py
+++ b/deptry/issue_finders/missing.py
@@ -28,7 +28,7 @@ class MissingDependenciesFinder:
 
     def _is_missing(self, module: Module) -> bool:
 
-        if module.package is None and not module.dependency and not module.dev_dependency and not module.local_module:
+        if module.package is None and not module.is_dependency and not module.is_dev_dependency and not module.local_module:
             if module.name in self.ignore_missing:
                 logging.debug(f"Identified module '{module.name}' as a missing dependency, but ignoring.")
             else:

--- a/deptry/issue_finders/missing.py
+++ b/deptry/issue_finders/missing.py
@@ -28,7 +28,12 @@ class MissingDependenciesFinder:
 
     def _is_missing(self, module: Module) -> bool:
 
-        if module.package is None and not module.is_dependency and not module.is_dev_dependency and not module.local_module:
+        if (
+            module.package is None
+            and not module.is_dependency
+            and not module.is_dev_dependency
+            and not module.local_module
+        ):
             if module.name in self.ignore_missing:
                 logging.debug(f"Identified module '{module.name}' as a missing dependency, but ignoring.")
             else:

--- a/deptry/issue_finders/obsolete.py
+++ b/deptry/issue_finders/obsolete.py
@@ -37,10 +37,6 @@ class ObsoleteDependenciesFinder:
 
     def _is_obsolete(self, dependency: Dependency) -> bool:
 
-        if dependency.is_conditional:
-            logging.debug("Conditional dependency, so ignoring it.")
-            return False
-
         if not self._dependency_found_in_imported_modules(dependency) and not self._any_of_the_top_levels_imported(
             dependency
         ):

--- a/deptry/issue_finders/obsolete.py
+++ b/deptry/issue_finders/obsolete.py
@@ -37,7 +37,7 @@ class ObsoleteDependenciesFinder:
 
     def _is_obsolete(self, dependency: Dependency) -> bool:
 
-        if dependency.conditional:
+        if dependency.is_conditional:
             logging.debug("Conditional dependency, so ignoring it.")
             return False
 

--- a/deptry/issue_finders/transitive.py
+++ b/deptry/issue_finders/transitive.py
@@ -36,8 +36,8 @@ class TransitiveDependenciesFinder:
     def _is_transitive(self, module: Module) -> bool:
         if (
             module.package is not None
-            and not module.dependency
-            and not module.dev_dependency
+            and not module.is_dependency
+            and not module.is_dev_dependency
             and not module.local_module
         ):
             if module.name in self.ignore_transitive:

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -72,11 +72,11 @@ class ModuleBuilder:
         standard_library = self._in_standard_library()
         if standard_library:
             return Module(self.name, standard_library=True)
-        
+
         local_module = self._is_local_directory()
         if local_module:
             return Module(self.name, local_module=True)
-            
+
         package = self._get_package_name_from_metadata()
         top_levels = self._get_corresponding_top_levels_from(self.dependencies)
         dev_top_levels = self._get_corresponding_top_levels_from(self.dev_dependencies)
@@ -91,7 +91,6 @@ class ModuleBuilder:
             is_dependency=is_dependency,
             is_dev_dependency=is_dev_dependency,
         )
-
 
     def _get_package_name_from_metadata(self) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,6 @@ exclude = [
 exclude = [
   '.venv','docs','tests'
 ]
-ignore_missing = [
-  'importlib_metadata'
-]
 
 [tool.poetry.scripts]
 deptry = "deptry.cli:deptry"

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -4,4 +4,10 @@ from deptry.dependency import Dependency
 def test_simple_dependency():
     dependency = Dependency("click")
     assert dependency.name == "click"
-    assert dependency.top_levels == ["click"]
+    assert dependency.top_levels == set(["click"])
+
+
+def test_create_default_top_level_if_metadata_not_found():
+    dependency = Dependency("Foo-bar")
+    assert dependency.name == "Foo-bar"
+    assert dependency.top_levels == set(["foo_bar"])

--- a/tests/test_dependency_getter.py
+++ b/tests/test_dependency_getter.py
@@ -1,0 +1,41 @@
+from deptry.dependency import Dependency
+from deptry.dependency_getter import DependencyGetter
+from deptry.utils import run_within_dir
+
+
+def test_dependency_getter(tmp_path):
+
+    fake_pyproject_toml = """[tool.poetry.dependencies]
+python = ">=3.7,<4.0"
+toml = "^0.10.2"
+foo =  { version = ">=2.5.1,<4.0.0", optional = true }
+bar =  { version = ">=2.5.1,<4.0.0", python = ">3.7" }
+foo-bar =  { version = ">=2.5.1,<4.0.0", optional = true, python = ">3.7" }"""
+
+    with run_within_dir(tmp_path):
+        with open("pyproject.toml", "w") as f:
+            f.write(fake_pyproject_toml)
+
+        dependencies = DependencyGetter().get()
+
+        assert len(dependencies) == 4
+
+        assert dependencies[0].name == "toml"
+        assert not dependencies[0].is_conditional
+        assert not dependencies[0].is_optional
+        assert "toml" in dependencies[0].top_levels
+
+        assert dependencies[1].name == "foo"
+        assert not dependencies[1].is_conditional
+        assert dependencies[1].is_optional
+        assert "foo" in dependencies[1].top_levels
+
+        assert dependencies[2].name == "bar"
+        assert dependencies[2].is_conditional
+        assert not dependencies[2].is_optional
+        assert "bar" in dependencies[2].top_levels
+
+        assert dependencies[3].name == "foo-bar"
+        assert dependencies[3].is_conditional
+        assert dependencies[3].is_optional
+        assert "foo_bar" in dependencies[3].top_levels

--- a/tests/test_obsolete_dependencies_finder.py
+++ b/tests/test_obsolete_dependencies_finder.py
@@ -23,7 +23,7 @@ def test_simple_with_ignore():
 def test_top_level():
     """
     Test if top-level information is read, and correctly used to not mark a dependency as obsolete.
-    blackd is in the top-level of matplotlib, so black should not be marked as an obsolete dependency.
+    blackd is in the top-level of black, so black should not be marked as an obsolete dependency.
     """
     dependencies = [Dependency("black")]
     modules = [ModuleBuilder("blackd", dependencies).build()]


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

If a dependency is not installed, and thus no metadata is found, it will now by default get one top-level module name, which is lowercase and with '-' replaced with '_'. So e.g. `importlib-metadata` will by default get `importlib_metadata` as a top-level module.

If this happens, a warning is displayed in the console to inform the user.