### PR TITLE
Switch to `tomli`/`tomllib` for parsing TOML

### DIFF
--- a/deptry/utils.py
+++ b/deptry/utils.py
@@ -5,7 +5,10 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Dict, Tuple
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 PYPROJECT_TOML_PATH = "./pyproject.toml"
 
@@ -49,8 +52,7 @@ def import_importlib_metadata() -> Tuple[types.ModuleType, Exception]:
 
 def load_pyproject_toml(pyproject_toml_path: str = PYPROJECT_TOML_PATH) -> Dict:
     try:
-        pyproject_text = Path(pyproject_toml_path).read_text()
-        pyproject_data = toml.loads(pyproject_text)
-        return pyproject_data
+        with Path(pyproject_toml_path).open("rb") as pyproject_file:
+            return tomllib.load(pyproject_file)
     except FileNotFoundError:
         raise FileNotFoundError(f"No file `pyproject.toml` found in directory {os.getcwd()}")

--- a/deptry/utils.py
+++ b/deptry/utils.py
@@ -7,6 +7,8 @@ from typing import Dict, Tuple
 
 import toml
 
+PYPROJECT_TOML_PATH = "./pyproject.toml"
+
 
 @contextmanager
 def run_within_dir(path: Path) -> None:
@@ -45,9 +47,9 @@ def import_importlib_metadata() -> Tuple[types.ModuleType, Exception]:
         return metadata, PackageNotFoundError
 
 
-def load_pyproject_toml() -> Dict:
+def load_pyproject_toml(pyproject_toml_path: str = PYPROJECT_TOML_PATH) -> Dict:
     try:
-        pyproject_text = Path("./pyproject.toml").read_text()
+        pyproject_text = Path(pyproject_toml_path).read_text()
         pyproject_data = toml.loads(pyproject_text)
         return pyproject_data
     except FileNotFoundError:

--- a/poetry.lock
+++ b/poetry.lock
@@ -295,18 +295,10 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -341,7 +333,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "936d62af9ae8b787c0245a15df436898f13b7af31fead490755eded752230b63"
+content-hash = "7cd351242d367f4c57c606ea88fb84495c42e9ce2f5542fd14b6e69d8c28487a"
 
 [metadata.files]
 attrs = [
@@ -529,10 +521,6 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
-]
-toml = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-toml = "^0.10.2"
+tomli = { version = "^2.0.1", python = "<3.11" }
 isort = "^5.10.1"
 click = "^8.0.0"
 importlib-metadata = { version = "*", python = "<=3.7" }
@@ -71,6 +71,7 @@ exclude = [
 exclude = [
   'venv','.venv','docs','tests'
 ]
+ignore_missing = ["tomllib"]
 
 [tool.poetry.scripts]
 deptry = "deptry.cli:deptry"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,25 @@
+from deptry.utils import load_pyproject_toml
+
+
+def test_load_pyproject_toml():
+    assert load_pyproject_toml("tests/data/example_project/pyproject.toml") == {
+        "tool": {
+            "deptry": {"ignore_obsolete": ["pkginfo"]},
+            "poetry": {
+                "authors": ["test <test@test.com>"],
+                "dependencies": {
+                    "click": "^8.1.3",
+                    "isort": "^5.10.1",
+                    "pkginfo": "^1.8.3",
+                    "python": ">=3.7,<4.0",
+                    "requests": "^2.28.1",
+                    "toml": "^0.10.2",
+                    "urllib3": "^1.26.12",
+                },
+                "description": "A test project",
+                "dev-dependencies": {"black": "^22.6.0"},
+                "name": "test",
+                "version": "0.0.1",
+            },
+        }
+    }


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Replace the library used for parsing `pyproject.toml` by [tomli](https://pypi.org/project/tomli/) on Python < 3.11 and [tomllib](https://docs.python.org/3.11/library/tomllib.html) on Python 3.11+.

`tomli` provides the same API as `tomllib`, which will be [included in Python 3.11](https://docs.python.org/3.11/whatsnew/3.11.html), so it is more future-proof.
Besides, `toml` is [mostly unmaintained](https://github.com/uiri/toml/commits/master).