### PR TITLE
docs(pyproject): add missing `extend_exclude`

### DIFF
--- a/docs/docs/pyproject-toml.md
+++ b/docs/docs/pyproject-toml.md
@@ -4,18 +4,19 @@
 
 _deptry_ can be configured by adding a `[tool.deptry]` section to _pyproject.toml_. The possible arguments are:
 
-- `exclude`: `List`
+- `exclude`: `List[str]`
+- `extend_exclude`: `List[str]`
 - `ignore_notebooks`: `bool`
-- `ignore_obsolete`: `List`
-- `ignore_missing`: `List`
-- `ignore_misplaced_dev`: `List`
-- `ignore_transitive`: `List`
+- `ignore_obsolete`: `List[str]`
+- `ignore_missing`: `List[str]`
+- `ignore_misplaced_dev`: `List[str]`
+- `ignore_transitive`: `List[str]`
 - `skip_obsolete`: `bool`
 - `skip_missing`: `bool`
 - `skip_transitive`: `bool`
 - `skip_misplaced_dev`: `bool`
 - `requirements_txt`: `str`
-- `requirements_txt_dev`: `List`
+- `requirements_txt_dev`: `List[str]`
 
 Note that the command line arguments that should be passed as a string with comma-separated values should simply be passed as a list in _pyproject.toml_.
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

`extend_exclude` is missing from the `pyproject.toml` configuration documentation.
Also took the occasion to add the expected type for the lists elements.