### PR TITLE
chore(codecov): fix misplaced `status`

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -2,12 +2,13 @@ coverage:
   range: 70..100
   round: down
   precision: 1
-ignore:
-  - "deptry/cli.py"
-  - "deptry/core.py"
-  - "deptry/utils.py"
   status:
     project:
       default:
         target: 90%
         threshold: .5%
+
+ignore:
+  - "deptry/cli.py"
+  - "deptry/core.py"
+  - "deptry/utils.py"


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

`status` key in Codecov configuration is misplaced, since it it is currently under `ignore` instead of `coverage`, as shown [in the documentation](https://docs.codecov.com/docs/commit-status).