### PR TITLE
Add some helpful `flake8` plugins

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,5 @@ repos:
     rev: "5.0.4"
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-bugbear==22.9.23

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,4 @@ repos:
       - id: flake8
         additional_dependencies:
           - flake8-bugbear==22.9.23
+          - flake8-comprehensions==3.10.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,4 @@ repos:
         additional_dependencies:
           - flake8-bugbear==22.9.23
           - flake8-comprehensions==3.10.0
+          - flake8-simplify==0.19.3

--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import re
-from typing import List, Optional, Tuple, Union
+from typing import List, Optional, Tuple
 
 from deptry.dependency import Dependency
 
@@ -62,7 +62,7 @@ class RequirementsTxtDependencyGetter:
 
         return dependencies
 
-    def _extract_dependency_from_line(self, line: str) -> Union[Dependency, None]:
+    def _extract_dependency_from_line(self, line: str) -> Optional[Dependency]:
         """
         Extract a dependency from a single line of a requirements.txt file.
         """
@@ -77,7 +77,7 @@ class RequirementsTxtDependencyGetter:
         else:
             return None
 
-    def _find_dependency_name_in(self, line: str) -> Union[str, None]:
+    def _find_dependency_name_in(self, line: str) -> Optional[str]:
         """
         Find the dependency name of a dependency specified according to the pip-standards for requirement.txt
         """
@@ -99,11 +99,11 @@ class RequirementsTxtDependencyGetter:
 
     @staticmethod
     def _check_if_dependency_is_optional(line: str) -> bool:
-        return True if re.findall(r"\[([a-zA-Z0-9-]+?)\]", line) else False
+        return bool(re.findall(r"\[([a-zA-Z0-9-]+?)\]", line))
 
     @staticmethod
     def _check_if_dependency_is_conditional(line: str) -> bool:
-        return True if ";" in line else False
+        return ";" in line
 
     def _log_dependencies(self, dependencies: List[Dependency]) -> None:
         logging.debug(f"The project contains the following {'dev-' if self.dev else ''}dependencies:")
@@ -116,7 +116,7 @@ class RequirementsTxtDependencyGetter:
         return re.search("^(http|https|git\+https)", line)
 
     @staticmethod
-    def _extract_name_from_url(line: str) -> Union[str, None]:
+    def _extract_name_from_url(line: str) -> Optional[str]:
 
         # Try to find egg, for url like git+https://github.com/xxxxx/package@xxxxx#egg=package
         match = re.search("egg=([a-zA-Z0-9-_]*)", line)

--- a/deptry/import_parser.py
+++ b/deptry/import_parser.py
@@ -23,7 +23,7 @@ class ImportParser:
         logging.info(f"Scanning {len(list_of_files)} files...")
         modules_per_file = [self.get_imported_modules_from_file(file) for file in list_of_files]
         all_modules = self._flatten_list(modules_per_file)
-        unique_modules = sorted(list(set(all_modules)))
+        unique_modules = sorted(set(all_modules))
         unique_modules = self._filter_exceptions(unique_modules)
         logging.debug(f"All imported modules: {unique_modules}\n")
         return unique_modules
@@ -34,7 +34,7 @@ class ImportParser:
                 modules = self._get_imported_modules_from_ipynb(path_to_file)
             else:
                 modules = self._get_imported_modules_from_py(path_to_file)
-            modules = sorted(list(set(modules)))
+            modules = sorted(set(modules))
             logging.debug(f"Found the following imports in {str(path_to_file)}: {modules}")
         except AttributeError as e:
             logging.warning(f"Warning: Parsing imports for file {str(path_to_file)} failed.")

--- a/deptry/issue_finders/misplaced_dev.py
+++ b/deptry/issue_finders/misplaced_dev.py
@@ -36,9 +36,8 @@ class MisplacedDevDependenciesFinder:
         for module in self.imported_modules:
             logging.debug(f"Scanning module {module.name}...")
             corresponding_package_name = self._get_package_name(module)
-            if corresponding_package_name:
-                if self._is_development_dependency(module, corresponding_package_name):
-                    misplaced_dev_dependencies.append(corresponding_package_name)
+            if corresponding_package_name and self._is_development_dependency(module, corresponding_package_name):
+                misplaced_dev_dependencies.append(corresponding_package_name)
         return misplaced_dev_dependencies
 
     def _is_development_dependency(self, module: Module, corresponding_package_name: str) -> bool:

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -48,7 +48,12 @@ class Module:
 
 
 class ModuleBuilder:
-    def __init__(self, name: str, dependencies: List[Dependency] = [], dev_dependencies: List[Dependency] = []) -> None:
+    def __init__(
+        self,
+        name: str,
+        dependencies: Optional[List[Dependency]] = None,
+        dev_dependencies: Optional[List[Dependency]] = None,
+    ) -> None:
         """
         Create a Module object that represents an imported module.
 
@@ -58,8 +63,8 @@ class ModuleBuilder:
             dev-dependencies: A list of the project's development dependencies
         """
         self.name = name
-        self.dependencies = dependencies
-        self.dev_dependencies = dev_dependencies
+        self.dependencies = dependencies or []
+        self.dev_dependencies = dev_dependencies or []
 
     def build(self) -> Module:
         """


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

Add some helpful `flake8` plugins to the codebase:
- [flake8-bugbear](https://pypi.org/project/flake8-bugbear/) to find bugs/design flaws
- [flake8-comprehensions](https://pypi.org/project/flake8-comprehensions/) to simplify list/set/dict comprehensions
- [flake8-simplify](https://pypi.org/project/flake8-simplify/) to simplify over-complex code

Update code to comply with the new checks.

Raw list of suggestions:
- `flake8-bugbear`:
```python
deptry/module.py:51:68: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
deptry/module.py:51:109: B006 Do not use mutable data structures for argument defaults.  They are created during function definition time. All calls to the function reuse this one instance of that data structure, persisting changes between them.
```

- `flake8-comprehensions`:
```python
deptry/import_parser.py:26:26: C414 Unnecessary list call within sorted().
deptry/import_parser.py:37:23: C414 Unnecessary list call within sorted().
```

- `flake8-simplify`:
```python
deptry/dependency_getter/pyproject_toml.py:28:16: SIM201 Use 'dep != "python"' instead of 'not dep == "python"'
deptry/dependency_getter/pyproject_toml.py:52:9: SIM105 Use 'contextlib.suppress(KeyError)'
deptry/dependency_getter/pyproject_toml.py:56:9: SIM105 Use 'contextlib.suppress(KeyError)'
deptry/dependency_getter/pyproject_toml.py:71:39: SIM118 Use '"optional" in spec' instead of '"optional" in spec.keys()'
deptry/dependency_getter/pyproject_toml.py:78:39: SIM118 Use '"python" in spec' instead of '"python" in spec.keys()'
deptry/dependency_getter/pyproject_toml.py:78:67: SIM118 Use '"version" in spec' instead of '"version" in spec.keys()'
deptry/issue_finders/misplaced_dev.py:39:13: SIM102 Use a single if-statement instead of nested if-statements
deptry/import_parser.py:87:18: SIM101 Multiple isinstance-calls which can be merged into a single call for variable 'node'
deptry/import_parser.py:97:13: SIM102 Use a single if-statement instead of nested if-statements
deptry/import_parser.py:120:60: SIM201 Use 'module != exception' instead of 'not module == exception'
deptry/import_parser.py:125:19: SIM115 Use context handler for opening files
deptry/dependency_getter/requirements_txt.py:65:59: SIM907 Use 'Optional[Dependency]' instead of 'Union[Dependency, None]'
deptry/dependency_getter/requirements_txt.py:80:54: SIM907 Use 'Optional[str]' instead of 'Union[str, None]'
deptry/dependency_getter/requirements_txt.py:102:16: SIM210 Use 'bool(re.findall('\\[([a-zA-Z0-9-]+?)\\]', line))' instead of 'True if re.findall('\\[([a-zA-Z0-9-]+?)\\]', line) else False'
deptry/dependency_getter/requirements_txt.py:106:16: SIM210 Use 'bool(';' in line)' instead of 'True if ';' in line else False'
deptry/dependency_getter/requirements_txt.py:119:46: SIM907 Use 'Optional[str]' instead of 'Union[str, None]'
```