### PR TITLE
removed `exclude` from black configuration since it's not used by pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,19 +34,6 @@ line-length = 120
 include = '\.pyi?$'
 target-version = ['py39']
 fast = true
-exclude = '''
-(
-  /(                        # exclude a few common directories in the
-    \.git                   # root of the project
-    | \.pytest_cache
-    | python-venv
-    | \.venv
-    | venv
-    | build
-    | dist
-    | \.tox
-  ))
-'''
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
See https://github.com/psf/black/issues/438

If we ever want to exclude anything, we should add an exclude argument in `pre-commit-config.yaml`.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->