### PR TITLE
Fix `threshold` field in Codecov configuration and un-ignore modules

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -7,8 +7,3 @@ coverage:
       default:
         target: 90%
         threshold: 0.5%
-
-ignore:
-  - "deptry/cli.py"
-  - "deptry/core.py"
-  - "deptry/utils.py"

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,7 +6,7 @@ coverage:
     project:
       default:
         target: 90%
-        threshold: .5%
+        threshold: 0.5%
 
 ignore:
   - "deptry/cli.py"


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Checking Codecov shows that the configuration is correctly invalid, as shown by https://app.codecov.io/gh/fpgmaas/deptry/commit/a701a5ae931d5d3f0dc59abc797b871b39009879.

Using the method described in https://docs.codecov.com/docs/codecov-yaml#validate-your-repository-yaml to validate the configuration:
```bash
$ curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate
Error at ['coverage', 'status', 'project', 'default', 'threshold']: 
field 'threshold' cannot be coerced: 
curl: (22) The requested URL returned error: 400
```

With the change:
```bash
$ curl -sSL --fail-with-body --data-binary @codecov.yaml https://codecov.io/validate
Valid!

{
  "coverage": {
    "range": [
      70.0,
      100.0
    ],
    "round": "down",
    "precision": 1,
    "status": {
      "project": {
        "default": {
          "target": 90.0,
          "threshold": 0.5
        }
      }
    }
  }
}
```

Figured we could also un-ignore the modules currently ignored, since this will force us to add tests if coverage is not enough in those modules.

Also see https://github.com/fpgmaas/deptry/pull/144 that suggests to add a CI workflow to ensure that the configuration is not broken on updates.