### PR TITLE
Update `black` configuration

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -42,7 +42,10 @@ def configure_logger(ctx: click.Context, _param: click.Parameter, value: bool) -
     "--verbose",
     "-v",
     is_flag=True,
-    help="Boolean flag for verbosity. Using this flag will display more information about files, imports and dependencies while running.",
+    help=(
+        "Boolean flag for verbosity. Using this flag will display more information about files, imports and"
+        " dependencies while running."
+    ),
     is_eager=True,
     callback=configure_logger,
 )
@@ -64,7 +67,10 @@ def configure_logger(ctx: click.Context, _param: click.Parameter, value: bool) -
 @click.option(
     "--skip-misplaced-dev",
     is_flag=True,
-    help="Boolean flag to specify if deptry should skip scanning the project for development dependencies that should be regular dependencies.",
+    help=(
+        "Boolean flag to specify if deptry should skip scanning the project for development dependencies that should be"
+        " regular dependencies."
+    ),
 )
 @click.option(
     "--ignore-obsolete",
@@ -207,7 +213,6 @@ def deptry(
         sys.exit(1)
 
     with run_within_dir(root):
-
         Core(
             ignore_obsolete=ignore_obsolete,
             ignore_missing=ignore_missing,

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -37,7 +37,6 @@ class Core:
     json_output: str
 
     def run(self) -> None:
-
         self._log_config()
 
         dependency_management_format = DependencySpecificationDetector(requirements_txt=self.requirements_txt).detect()

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -48,7 +48,8 @@ class Dependency:
             return True
         except PackageNotFoundError:
             logging.warning(
-                f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its corresponding module name is '{name.replace('-','_').lower()}'."
+                f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its"
+                f" corresponding module name is '{name.replace('-','_').lower()}'."
             )
             return False
 

--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -122,7 +122,6 @@ class RequirementsTxtDependencyGetter:
 
     @staticmethod
     def _extract_name_from_url(line: str) -> Optional[str]:
-
         # Try to find egg, for url like git+https://github.com/xxxxx/package@xxxxx#egg=package
         match = re.search("egg=([a-zA-Z0-9-_]*)", line)
         if match:

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -23,22 +23,26 @@ class DependencySpecificationDetector:
         uses_requirements_txt = self._check_if_project_uses_requirements_txt_for_dependencies()
         if uses_pyproject_toml and uses_requirements_txt:
             logging.info(
-                f"Found both 'pyproject.toml' with a [tool.poetry.dependencies] section and '{', '.join(self.requirements_txt)}' requirements file(s). Defaulting to 'pyproject.toml'.\n"
+                "Found both 'pyproject.toml' with a [tool.poetry.dependencies] section and"
+                f" '{', '.join(self.requirements_txt)}' requirements file(s). Defaulting to 'pyproject.toml'.\n"
             )
             return "pyproject_toml"
         elif uses_pyproject_toml:
             logging.debug(
-                "Dependency specification found in 'pyproject.toml'. Will use this to determine the project's dependencies.\n"
+                "Dependency specification found in 'pyproject.toml'. Will use this to determine the project's"
+                " dependencies.\n"
             )
             return "pyproject_toml"
         elif uses_requirements_txt:
             logging.debug(
-                f"Dependency specification found in '{', '.join(self.requirements_txt)}'. Will use this to determine the project's dependencies.\n"
+                f"Dependency specification found in '{', '.join(self.requirements_txt)}'. Will use this to determine"
+                " the project's dependencies.\n"
             )
             return "requirements_txt"
         else:
             raise FileNotFoundError(
-                f"No file called 'pyproject.toml' with a [tool.poetry.dependencies] section or called '{', '.join(self.requirements_txt)}' found. Exiting."
+                "No file called 'pyproject.toml' with a [tool.poetry.dependencies] section or called"
+                f" '{', '.join(self.requirements_txt)}' found. Exiting."
             )
 
     @staticmethod
@@ -49,12 +53,14 @@ class DependencySpecificationDetector:
             try:
                 pyproject_toml["tool"]["poetry"]["dependencies"]
                 logging.debug(
-                    "pyproject.toml contains a [tool.poetry.dependencies] section, so it is used to specify the project's dependencies."
+                    "pyproject.toml contains a [tool.poetry.dependencies] section, so it is used to specify the"
+                    " project's dependencies."
                 )
                 return True
             except KeyError:
                 logging.debug(
-                    "pyproject.toml does not contain a [tool.poetry.dependencies] section, so it is not used to specify the project's dependencies."
+                    "pyproject.toml does not contain a [tool.poetry.dependencies] section, so it is not used to specify"
+                    " the project's dependencies."
                 )
                 pass
 

--- a/deptry/issue_finders/misplaced_dev.py
+++ b/deptry/issue_finders/misplaced_dev.py
@@ -44,7 +44,8 @@ class MisplacedDevDependenciesFinder:
         if module.is_dev_dependency:
             if module.name in self.ignore_misplaced_dev:
                 logging.debug(
-                    f"Module '{corresponding_package_name}' found to be a misplaced development dependency, but ignoring."
+                    f"Module '{corresponding_package_name}' found to be a misplaced development dependency, but"
+                    " ignoring."
                 )
             else:
                 logging.debug(
@@ -59,7 +60,8 @@ class MisplacedDevDependenciesFinder:
         if module.dev_top_levels:
             if len(module.dev_top_levels) > 1:
                 logging.debug(
-                    f"Module {module.name} is found in the top-level module names of multiple development dependencies. Skipping."
+                    f"Module {module.name} is found in the top-level module names of multiple development dependencies."
+                    " Skipping."
                 )
             elif len(module.dev_top_levels) == 0:
                 logging.debug(

--- a/deptry/issue_finders/missing.py
+++ b/deptry/issue_finders/missing.py
@@ -27,7 +27,6 @@ class MissingDependenciesFinder:
         return missing_dependencies
 
     def _is_missing(self, module: Module) -> bool:
-
         if (
             module.package is None
             and not module.is_dependency

--- a/deptry/issue_finders/obsolete.py
+++ b/deptry/issue_finders/obsolete.py
@@ -27,7 +27,6 @@ class ObsoleteDependenciesFinder:
         logging.debug("\nScanning for obsolete dependencies...")
         obsolete_dependencies = []
         for dependency in self.dependencies:
-
             logging.debug(f"Scanning module {dependency.name}...")
 
             if self._is_obsolete(dependency):
@@ -36,7 +35,6 @@ class ObsoleteDependenciesFinder:
         return obsolete_dependencies
 
     def _is_obsolete(self, dependency: Dependency) -> bool:
-
         if not self._dependency_found_in_imported_modules(dependency) and not self._any_of_the_top_levels_imported(
             dependency
         ):

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -118,7 +118,8 @@ class ModuleBuilder:
 
     def _get_stdlib_packages(self) -> Set[str]:
         incorrect_version_error = ValueError(
-            f"Incorrect Python version {'.'.join([str(x) for x in sys.version_info[0:3]])}. Only 3.7, 3.8, 3.9, and 3.10 are currently supported."
+            f"Incorrect Python version {'.'.join([str(x) for x in sys.version_info[0:3]])}. Only 3.7, 3.8, 3.9, and"
+            " 3.10 are currently supported."
         )
         if sys.version_info[0] == 3:
             if sys.version_info[1] == 7:

--- a/deptry/result_logger.py
+++ b/deptry/result_logger.py
@@ -43,21 +43,24 @@ class ResultLogger:
     def _log_missing_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
-            f"There are dependencies missing from the project's list of dependencies:\n{sep}{sep.join(sorted(dependencies))}\n"
+            "There are dependencies missing from the project's list of"
+            f" dependencies:\n{sep}{sep.join(sorted(dependencies))}\n"
         )
         logging.info("""Consider adding them to your project's dependencies. """)
 
     def _log_transitive_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
-            f"There are transitive dependencies that should be explicitly defined as dependencies:\n{sep}{sep.join(sorted(dependencies))}\n"
+            "There are transitive dependencies that should be explicitly defined as"
+            f" dependencies:\n{sep}{sep.join(sorted(dependencies))}\n"
         )
         logging.info("""They are currently imported but not specified directly as your project's dependencies.""")
 
     def _log_misplaced_develop_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
-            f"There are imported modules from development dependencies detected:\n{sep}{sep.join(sorted(dependencies))}\n"
+            "There are imported modules from development dependencies"
+            f" detected:\n{sep}{sep.join(sorted(dependencies))}\n"
         )
         logging.info(
             """Consider moving them to your project's 'regular' dependencies. If this is not correct and the dependencies listed above are indeed development dependencies, it's likely that files were scanned that are only used for development purposes. Run `deptry -v .` to see a list of scanned files."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,8 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 120
-include = '\.pyi?$'
-target-version = ['py39']
-fast = true
+target-version = ["py37"]
+preview = true
 
 [tool.isort]
 profile = "black"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,8 @@ def requirements_txt_dir_with_venv_installed(tmp_path_factory):
     with run_within_dir(str(tmp_path_proj)):
         subprocess.check_call(
             shlex.split(
-                "pip install -r requirements.txt -r requirements-dev.txt -r requirements-2.txt -r requirements-typing.txt"
+                "pip install -r requirements.txt -r requirements-dev.txt -r requirements-2.txt -r"
+                " requirements-typing.txt"
             )
         ) == 0
     return tmp_path_proj
@@ -95,7 +96,15 @@ def test_cli_single_requirements_txt(requirements_txt_dir_with_venv_installed):
         )
         assert result.returncode == 1
         assert (
-            "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\nConsider removing them from your project's dependencies. If a package is used for development purposes, you should add it to your development dependencies instead.\n\n-----------------------------------------------------\n\nThere are dependencies missing from the project's list of dependencies:\n\n\twhite\n\nConsider adding them to your project's dependencies. \n\n-----------------------------------------------------\n\nThere are transitive dependencies that should be explicitly defined as dependencies:\n\n\turllib3\n\nThey are currently imported but not specified directly as your project's dependencies.\n\n-----------------------------------------------------\n\nThere are imported modules from development dependencies detected:\n\n\tblack\n\n"
+            "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\nConsider removing them from your"
+            " project's dependencies. If a package is used for development purposes, you should add it to your"
+            " development dependencies instead.\n\n-----------------------------------------------------\n\nThere are"
+            " dependencies missing from the project's list of dependencies:\n\n\twhite\n\nConsider adding them to your"
+            " project's dependencies. \n\n-----------------------------------------------------\n\nThere are transitive"
+            " dependencies that should be explicitly defined as dependencies:\n\n\turllib3\n\nThey are currently"
+            " imported but not specified directly as your project's"
+            " dependencies.\n\n-----------------------------------------------------\n\nThere are imported modules from"
+            " development dependencies detected:\n\n\tblack\n\n"
             in result.stderr
         )
 
@@ -104,14 +113,20 @@ def test_cli_multiple_requirements_txt(requirements_txt_dir_with_venv_installed)
     with run_within_dir(str(requirements_txt_dir_with_venv_installed)):
         result = subprocess.run(
             shlex.split(
-                "deptry . --requirements-txt requirements.txt,requirements-2.txt --requirements-txt-dev requirements-dev.txt,requirements-typing.txt"
+                "deptry . --requirements-txt requirements.txt,requirements-2.txt --requirements-txt-dev"
+                " requirements-dev.txt,requirements-typing.txt"
             ),
             capture_output=True,
             text=True,
         )
         assert result.returncode == 1
         assert (
-            "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\nConsider removing them from your project's dependencies. If a package is used for development purposes, you should add it to your development dependencies instead.\n\n-----------------------------------------------------\n\nThere are dependencies missing from the project's list of dependencies:\n\n\twhite\n\nConsider adding them to your project's dependencies. \n\n-----------------------------------------------------\n\nThere are imported modules from development dependencies detected:\n\n\tblack\n\n"
+            "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\nConsider removing them from your"
+            " project's dependencies. If a package is used for development purposes, you should add it to your"
+            " development dependencies instead.\n\n-----------------------------------------------------\n\nThere are"
+            " dependencies missing from the project's list of dependencies:\n\n\twhite\n\nConsider adding them to your"
+            " project's dependencies. \n\n-----------------------------------------------------\n\nThere are imported"
+            " modules from development dependencies detected:\n\n\tblack\n\n"
             in result.stderr
         )
 
@@ -130,7 +145,6 @@ def test_cli_verbose(dir_with_venv_installed):
 
 def test_cli_with_json_output(dir_with_venv_installed):
     with run_within_dir(str(dir_with_venv_installed)):
-
         # assert that there is no json output
         subprocess.run(shlex.split("poetry run deptry ."), capture_output=True, text=True)
         assert len(list(pathlib.Path(".").glob("*.json"))) == 0

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -28,7 +28,6 @@ def test_both(tmp_path):
     """
 
     with run_within_dir(tmp_path):
-
         with open("pyproject.toml", "w") as f:
             f.write('[tool.poetry.dependencies]\nfake = "10"')
 

--- a/tests/test_import_parser.py
+++ b/tests/test_import_parser.py
@@ -89,7 +89,6 @@ def test_import_parser_ignores_setuptools(tmp_path):
 
 
 def test_import_parser_file_encodings(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("file1.py", "w", encoding="utf-8") as f:
             f.write(
@@ -133,7 +132,6 @@ print('嘉大')
 
 
 def test_import_parser_file_encodings_warning(tmp_path, caplog):
-
     with run_within_dir(tmp_path):
         with open("file1.py", "w", encoding="utf-8") as f:
             f.write("print('this is a mock unparseable file')")

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -5,7 +5,6 @@ from deptry.utils import run_within_dir
 
 
 def test_simple(tmp_path):
-
     with run_within_dir(tmp_path):
         JsonWriter(json_output="output.json").write(issues={"one": "two", "three": "four"})
 

--- a/tests/test_pyproject_toml_dependency_getter.py
+++ b/tests/test_pyproject_toml_dependency_getter.py
@@ -4,7 +4,6 @@ from deptry.utils import run_within_dir
 
 
 def test_dependency_getter(tmp_path):
-
     fake_pyproject_toml = """[tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 toml = "^0.10.2"
@@ -42,7 +41,6 @@ foo-bar =  { version = ">=2.5.1,<4.0.0", optional = true, python = ">3.7" }"""
 
 
 def test_dependency_getter_dev(tmp_path):
-
     fake_pyproject_toml = """[tool.poetry.dev-dependencies]
 toml = "^0.10.2"
 foo =  { version = ">=2.5.1,<4.0.0", optional = true }

--- a/tests/test_python_file_finder.py
+++ b/tests/test_python_file_finder.py
@@ -55,7 +55,6 @@ def test_only_matches_start(tmp_path):
 
 
 def test_matches_ipynb(tmp_path):
-
     with run_within_dir(tmp_path):
         paths = [
             {"dir": "dir/subdir", "file": "file1.ipynb"},
@@ -70,7 +69,6 @@ def test_matches_ipynb(tmp_path):
 
 
 def test_regex_argument(tmp_path):
-
     with run_within_dir(tmp_path):
         paths = [
             {"dir": "dir/subdir", "file": "file1.py"},

--- a/tests/test_requirements_txt_dependency_getter.py
+++ b/tests/test_requirements_txt_dependency_getter.py
@@ -4,7 +4,6 @@ from deptry.utils import run_within_dir
 
 
 def test_parse_requirements_txt(tmp_path):
-
     fake_requirements_txt = """click==8.1.3 #123asd
 colorama==0.4.5
 importlib-metadata==4.2.0 ; python_version >= "3.7" and python_version < "3.8"
@@ -50,7 +49,6 @@ requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
 
 
 def test_parse_requirements_txt_urls(tmp_path):
-
     fake_requirements_txt = """urllib3 @ https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
 https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
 git+https://github.com/baz/foo-bar.git@asd#egg=foo-bar
@@ -72,7 +70,6 @@ git+https://github.com/abc123/bar-foo@xyz789#egg=bar-fooo"""
 
 
 def test_single(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("req.txt", "w") as f:
             f.write("click==8.1.3 #123asd\ncolorama==0.4.5")
@@ -84,7 +81,6 @@ def test_single(tmp_path):
 
 
 def test_multiple(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("foo.txt", "w") as f:
             f.write("click==8.1.3 #123asd")
@@ -98,7 +94,6 @@ def test_multiple(tmp_path):
 
 
 def test_dev_single(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("requirements-dev.txt", "w") as f:
             f.write("click==8.1.3 #123asd\ncolorama==0.4.5")
@@ -114,7 +109,6 @@ def test_dev_single(tmp_path):
 
 
 def test_dev_multiple(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("requirements-dev.txt", "w") as f:
             f.write("click==8.1.3 #123asd")
@@ -128,7 +122,6 @@ def test_dev_multiple(tmp_path):
 
 
 def test_dev_multiple_with_arguments(tmp_path):
-
     with run_within_dir(tmp_path):
         with open("foo.txt", "w") as f:
             f.write("click==8.1.3 #123asd")


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Update `black` configuration:
- `target-version` should be set to the minimum Python we support
- `fast`, while faster, [doesn't check that the AST after reformatting is valid](https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#ast-before-and-after-formatting), meaning that there's no guarantee that the code still works; removing it should be safer
- `preview` enables [future style updates](https://black.readthedocs.io/en/stable/the_black_code_style/future_style.html#preview-style), the most interesting one for the codebase being the split of long strings.
- `include` is removed because it's [already the default](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options)