### PR TITLE
Add support for PEP 621

### DIFF
--- a/deptry/core.py
+++ b/deptry/core.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract
 from deptry.dependency_getter.pdm import PDMDependencyGetter
+from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
 from deptry.dependency_getter.poetry import PoetryDependencyGetter
 from deptry.dependency_getter.requirements_txt import RequirementsTxtDependencyGetter
 from deptry.dependency_specification_detector import (
@@ -86,6 +87,8 @@ class Core:
             return PoetryDependencyGetter().get()
         if dependency_management_format is DependencyManagementFormat.PDM:
             return PDMDependencyGetter().get()
+        if dependency_management_format is DependencyManagementFormat.PEP_621:
+            return PEP621DependencyGetter().get()
         if dependency_management_format is DependencyManagementFormat.REQUIREMENTS_TXT:
             return RequirementsTxtDependencyGetter(self.requirements_txt, self.requirements_txt_dev).get()
         raise ValueError("Incorrect dependency manage format. Only poetry, pdm and requirements.txt are supported.")

--- a/deptry/dependency_getter/pdm.py
+++ b/deptry/dependency_getter/pdm.py
@@ -1,31 +1,26 @@
 import logging
-import re
-from typing import Dict, List, Optional
+from dataclasses import dataclass
+from typing import Dict, List
 
 from deptry.dependency import Dependency
-from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
+from deptry.dependency_getter.base import DependenciesExtract
+from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
 from deptry.utils import load_pyproject_toml
 
 
-class PDMDependencyGetter(DependencyGetter):
+@dataclass
+class PDMDependencyGetter(PEP621DependencyGetter):
     """
     Class to get dependencies that are specified according to PEP 621 from a `pyproject.toml` file for a project that uses PDM for its dependency management.
     """
 
     def get(self) -> DependenciesExtract:
-        dependencies = self._get_pdm_dependencies()
-        self._log_dependencies(dependencies)
+        pep_621_dependencies_extract = super().get()
 
         dev_dependencies = self._get_pdm_dev_dependencies()
         self._log_dependencies(dev_dependencies, is_dev=True)
 
-        return DependenciesExtract(dependencies, dev_dependencies)
-
-    @classmethod
-    def _get_pdm_dependencies(cls) -> List[Dependency]:
-        pyproject_data = load_pyproject_toml()
-        dependency_strings: List[str] = pyproject_data["project"]["dependencies"]
-        return cls._extract_dependency_objects_from(dependency_strings)
+        return DependenciesExtract(pep_621_dependencies_extract.dependencies, dev_dependencies)
 
     @classmethod
     def _get_pdm_dev_dependencies(cls) -> List[Dependency]:
@@ -52,31 +47,4 @@ class PDMDependencyGetter(DependencyGetter):
         except KeyError:
             logging.debug("No section [tool.pdm.dev-dependencies] found in pyproject.toml")
 
-        return cls._extract_dependency_objects_from(dev_dependency_strings)
-
-    @classmethod
-    def _extract_dependency_objects_from(cls, pdm_dependencies: List[str]) -> List[Dependency]:
-        dependencies = []
-        for spec in pdm_dependencies:
-            # An example of a spec is `"tomli>=1.1.0; python_version < \"3.11\""`
-            name = cls._find_dependency_name_in(spec)
-            if name:
-                optional = cls._is_optional(spec)
-                conditional = cls._is_conditional(spec)
-                dependencies.append(Dependency(name, conditional=conditional, optional=optional))
-        return dependencies
-
-    @staticmethod
-    def _is_optional(dependency_specification: str) -> bool:
-        return bool(re.findall(r"\[([a-zA-Z0-9-]+?)\]", dependency_specification))
-
-    @staticmethod
-    def _is_conditional(dependency_specification: str) -> bool:
-        return ";" in dependency_specification
-
-    @staticmethod
-    def _find_dependency_name_in(spec: str) -> Optional[str]:
-        match = re.search("[a-zA-Z0-9-_]+", spec)
-        if match:
-            return match.group(0)
-        return None
+        return cls._extract_pep_508_dependencies(dev_dependency_strings)

--- a/deptry/dependency_getter/pep_621.py
+++ b/deptry/dependency_getter/pep_621.py
@@ -1,0 +1,51 @@
+import re
+from dataclasses import dataclass
+from typing import List, Optional
+
+from deptry.dependency import Dependency
+from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
+from deptry.utils import load_pyproject_toml
+
+
+@dataclass
+class PEP621DependencyGetter(DependencyGetter):
+    def get(self) -> DependenciesExtract:
+        dependencies = self._get_dependencies()
+        self._log_dependencies(dependencies)
+
+        return DependenciesExtract(dependencies, [])
+
+    @classmethod
+    def _get_dependencies(cls) -> List[Dependency]:
+        pyproject_data = load_pyproject_toml()
+        dependency_strings: List[str] = pyproject_data["project"]["dependencies"]
+        return cls._extract_pep_508_dependencies(dependency_strings)
+
+    @classmethod
+    def _extract_pep_508_dependencies(cls, dependencies: List[str]) -> List[Dependency]:
+        extracted_dependencies = []
+
+        for spec in dependencies:
+            # An example of a spec is `"tomli>=1.1.0; python_version < \"3.11\""`
+            name = cls._find_dependency_name_in(spec)
+            if name:
+                extracted_dependencies.append(
+                    Dependency(name, conditional=cls._is_conditional(spec), optional=cls._is_optional(spec))
+                )
+
+        return extracted_dependencies
+
+    @staticmethod
+    def _is_optional(dependency_specification: str) -> bool:
+        return bool(re.findall(r"\[([a-zA-Z0-9-]+?)\]", dependency_specification))
+
+    @staticmethod
+    def _is_conditional(dependency_specification: str) -> bool:
+        return ";" in dependency_specification
+
+    @staticmethod
+    def _find_dependency_name_in(spec: str) -> Optional[str]:
+        match = re.search("[a-zA-Z0-9-_]+", spec)
+        if match:
+            return match.group(0)
+        return None

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -7,8 +7,9 @@ from deptry.utils import load_pyproject_toml
 
 
 class DependencyManagementFormat(Enum):
-    POETRY = "poetry"
     PDM = "pdm"
+    PEP_621 = "pep_621"
+    POETRY = "poetry"
     REQUIREMENTS_TXT = "requirements_txt"
 
 
@@ -17,6 +18,7 @@ class DependencySpecificationDetector:
     Class to detect how dependencies are specified:
     - Either find a pyproject.toml with a [poetry.tool.dependencies] section
     - Otherwise, find a pyproject.toml with a [tool.pdm] section
+    - Otherwise, find a pyproject.toml with a [project] section
     - Otherwise, find a requirements.txt.
 
     """
@@ -30,11 +32,13 @@ class DependencySpecificationDetector:
             return DependencyManagementFormat.POETRY
         if pyproject_toml_found and self._project_uses_pdm():
             return DependencyManagementFormat.PDM
+        if pyproject_toml_found and self._project_uses_pep_621():
+            return DependencyManagementFormat.PEP_621
         if self._project_uses_requirements_txt():
             return DependencyManagementFormat.REQUIREMENTS_TXT
         raise FileNotFoundError(
-            "No file called 'pyproject.toml' with a [tool.poetry.dependencies] or [tool.pdm] section or file(s)"
-            f" called '{', '.join(self.requirements_txt)}' found. Exiting."
+            "No file called 'pyproject.toml' with a [tool.poetry.dependencies], [tool.pdm] or [project] section or"
+            f" file(s) called '{', '.join(self.requirements_txt)}' found. Exiting."
         )
 
     @staticmethod
@@ -77,6 +81,23 @@ class DependencySpecificationDetector:
             logging.debug(
                 "pyproject.toml does not contain a [tool.pdm] section, so PDM is not used to specify"
                 " the project's dependencies."
+            )
+            pass
+        return False
+
+    @staticmethod
+    def _project_uses_pep_621() -> bool:
+        pyproject_toml = load_pyproject_toml()
+        try:
+            pyproject_toml["project"]
+            logging.debug(
+                "pyproject.toml contains a [project] section, so PEP 621 is used to specify the project's dependencies."
+            )
+            return True
+        except KeyError:
+            logging.debug(
+                "pyproject.toml does not contain a [project] section, so PEP 621 is not used to specify the project's"
+                " dependencies."
             )
             pass
         return False

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -72,14 +72,15 @@ class DependencySpecificationDetector:
     def _project_uses_pdm() -> bool:
         pyproject_toml = load_pyproject_toml()
         try:
-            pyproject_toml["tool"]["pdm"]
+            pyproject_toml["tool"]["pdm"]["dev-dependencies"]
             logging.debug(
-                "pyproject.toml contains a [tool.pdm] section, so PDM is used to specify the project's dependencies."
+                "pyproject.toml contains a [tool.pdm.dev-dependencies] section, so PDM is used to specify the project's"
+                " dependencies."
             )
             return True
         except KeyError:
             logging.debug(
-                "pyproject.toml does not contain a [tool.pdm] section, so PDM is not used to specify"
+                "pyproject.toml does not contain a [tool.pdm.dev-dependencies] section, so PDM is not used to specify"
                 " the project's dependencies."
             )
             pass

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -22,6 +22,7 @@ _deptry_ is a command line tool to check for issues with dependencies in a Pytho
 
 - Projects that use [Poetry](https://python-poetry.org/) and a corresponding _pyproject.toml_ file
 - Projects that use [PDM](https://pdm.fming.dev/latest/) and a corresponding _pyproject.toml_ file
+- Projects that use any package manager that strictly follows [PEP 621](https://peps.python.org/pep-0621/) dependency specification
 - Projects that use a _requirements.txt_ file according to the [pip](https://pip.pypa.io/en/stable/user_guide/) standards
 
 Dependency issues are detected by scanning for imported modules within all Python files in a directory and its subdirectories, and comparing those to the dependencies listed in the project's requirements.

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -16,13 +16,21 @@ deptry .
 
 Where `.` is the path to the root directory of the project to be scanned. All other arguments should be specified relative to this directory.
 
-## pyproject.toml vs requirements.txt
+## Dependencies extraction
 
 To determine the project's dependencies, _deptry_ will scan the root directory for files in the following order:
 
-- If a `pyproject.toml` file with a `[tool.poetry.dependencies]` section is found, _deptry_ will extract both the projects dependencies and its development dependencies from `pyproject.toml`.
-- If a `pyproject.toml` file with a `[tool.pdm]` section is found, _deptry_ will extract the projects dependencies from `dependencies` in the `[project]` section, and the development dependencies from `[tool.pdm.dev-dependencies]`.
-- If a `requirements.txt` file is found, _deptry_ will extract the project's dependencies from there, and additionally it will look for the files `dev-dependencies.txt` and `dependencies-dev.txt` to determine the project's development dependencies.
+- If a `pyproject.toml` file with a `[tool.poetry.dependencies]` section is found, _deptry_ will assume it uses Poetry and extract:
+  - dependencies from `[tool.poetry.dependencies]` section
+  - development dependencies from `[tool.poetry.group.dev.dependencies]` or `[tool.poetry.dev-dependencies]` section
+- If a `pyproject.toml` file with a `[tool.pdm.dev-dependencies]` section is found, _deptry_ will assume it uses PDM and extract:
+  - dependencies from `[project.dependencies]` and `[project.optional-dependencies]` sections
+  - development dependencies from `[tool.pdm.dev-dependencies]` section.
+- If a `pyproject.toml` file with a `[project]` section is found, _deptry_ will assume it uses [PEP 621](https://peps.python.org/pep-0621/) for dependency specification and extract:
+  - dependencies from `[project.dependencies]` and `[project.optional-dependencies]` sections
+- If a `requirements.txt` file is found, _deptry_ will extract:
+  - dependencies from it
+  - development dependencies from `dev-dependencies.txt` and `dependencies-dev.txt`, if any exist
 
 _deptry_ can also be configured to look for `requirements.txt` files with other names or in other directories. See [requirements.txt files](#requirementstxt-files).
 

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -21,9 +21,7 @@ def test_cli_with_pep_621(pep_621_dir_with_venv_installed):
         result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
         assert result.returncode == 1
         print(result.stderr)
-        assert "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\n" in result.stderr
-        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
         assert (
-            "There are transitive dependencies that should be explicitly defined as dependencies:\n\n\tblack\n\n"
-            in result.stderr
+            "The project contains obsolete dependencies:\n\n\tisort\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
         )
+        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -1,0 +1,29 @@
+import shlex
+import shutil
+import subprocess
+
+import pytest
+
+from deptry.utils import run_within_dir
+
+
+@pytest.fixture(scope="session")
+def pep_621_dir_with_venv_installed(tmp_path_factory):
+    tmp_path_proj = tmp_path_factory.getbasetemp() / "pep_621_project"
+    shutil.copytree("tests/data/pep_621_project", str(tmp_path_proj))
+    with run_within_dir(tmp_path_proj):
+        assert subprocess.check_call(shlex.split("pip install .")) == 0
+    return tmp_path_proj
+
+
+def test_cli_with_pep_621(pep_621_dir_with_venv_installed):
+    with run_within_dir(pep_621_dir_with_venv_installed):
+        result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
+        assert result.returncode == 1
+        print(result.stderr)
+        assert "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\n" in result.stderr
+        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
+        assert (
+            "There are transitive dependencies that should be explicitly defined as dependencies:\n\n\tblack\n\n"
+            in result.stderr
+        )

--- a/tests/data/pep_621_project/README.md
+++ b/tests/data/pep_621_project/README.md
@@ -11,12 +11,6 @@ requests
 pkginfo
 ```
 
-dev-dependencies:
-
-```
-black
-```
-
 ## Imports
 
 Imported in .py files are
@@ -49,6 +43,6 @@ So expected output without any additional configuration:
 ```
 obsolete: isort, requests (pkginfo is ignored)
 missing: white
-transitive: None
-dev: black
+transitive: black
+dev: None
 ```

--- a/tests/data/pep_621_project/pyproject.toml
+++ b/tests/data/pep_621_project/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
+version = "1.2.3"
+requires-python = ">=3.7"
+dependencies = [
+    "toml",
+    "urllib3>=1.26.12",
+    "isort>=5.10.1",
+    "click>=8.1.3",
+    "requests>=2.28.1",
+    "pkginfo>=1.8.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black==22.10.0",
+    "mypy==0.982",
+]
+test = [
+  "pytest==7.2.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.deptry]
+ignore_obsolete = ["pkginfo"]

--- a/tests/data/pep_621_project/src/main.py
+++ b/tests/data/pep_621_project/src/main.py
@@ -1,0 +1,7 @@
+from os import chdir, walk
+from pathlib import Path
+
+import black
+import click
+import white as w
+from urllib3 import contrib

--- a/tests/data/pep_621_project/src/notebook.ipynb
+++ b/tests/data/pep_621_project/src/notebook.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9f4924ec-2200-4801-9d49-d4833651cbc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import click\n",
+    "from urllib3 import contrib\n",
+    "import toml"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/data/project_with_pdm/pyproject.toml
+++ b/tests/data/project_with_pdm/pyproject.toml
@@ -5,10 +5,16 @@ requires-python = ">=3.7"
 dependencies = [
     "toml",
     "urllib3>=1.26.12",
+    "pkginfo>=1.8.3",
+]
+
+[project.optional-dependencies]
+foo = [
     "isort>=5.10.1",
     "click>=8.1.3",
-    "requests>=2.28.1",
-    "pkginfo>=1.8.3",
+]
+bar = [
+  "requests>=2.28.1",
 ]
 
 [tool.pdm]
@@ -20,6 +26,4 @@ lint = [
 ]
 
 [tool.deptry]
-ignore_obsolete = [
-'pkginfo'
-]
+ignore_obsolete = ["pkginfo"]

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -1,0 +1,43 @@
+from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
+from deptry.utils import run_within_dir
+
+
+def test_dependency_getter(tmp_path):
+    fake_pyproject_toml = """[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+dependencies = [
+    "foo",
+    "bar>=20.9",
+    "optional-foo[option]>=0.12.11",
+    "conditional-bar>=1.1.0; python_version < 3.11",
+]
+"""
+
+    with run_within_dir(tmp_path):
+        with open("pyproject.toml", "w") as f:
+            f.write(fake_pyproject_toml)
+
+        dependencies = PEP621DependencyGetter().get().dependencies
+
+        assert len(dependencies) == 4
+
+        assert dependencies[0].name == "foo"
+        assert not dependencies[0].is_conditional
+        assert not dependencies[0].is_optional
+        assert "foo" in dependencies[0].top_levels
+
+        assert dependencies[1].name == "bar"
+        assert not dependencies[1].is_conditional
+        assert not dependencies[1].is_optional
+        assert "bar" in dependencies[1].top_levels
+
+        assert dependencies[2].name == "optional-foo"
+        assert not dependencies[2].is_conditional
+        assert dependencies[2].is_optional
+        assert "optional_foo" in dependencies[2].top_levels
+
+        assert dependencies[3].name == "conditional-bar"
+        assert dependencies[3].is_conditional
+        assert not dependencies[3].is_optional
+        assert "conditional_bar" in dependencies[3].top_levels

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -12,6 +12,15 @@ dependencies = [
     "optional-foo[option]>=0.12.11",
     "conditional-bar>=1.1.0; python_version < 3.11",
 ]
+
+[project.optional-dependencies]
+group1 = [
+    "foobar",
+    "barfoo",
+]
+group2 = [
+    "dep",
+]
 """
 
     with run_within_dir(tmp_path):
@@ -20,7 +29,7 @@ dependencies = [
 
         dependencies = PEP621DependencyGetter().get().dependencies
 
-        assert len(dependencies) == 4
+        assert len(dependencies) == 7
 
         assert dependencies[0].name == "foo"
         assert not dependencies[0].is_conditional
@@ -41,3 +50,18 @@ dependencies = [
         assert dependencies[3].is_conditional
         assert not dependencies[3].is_optional
         assert "conditional_bar" in dependencies[3].top_levels
+
+        assert dependencies[4].name == "foobar"
+        assert not dependencies[4].is_conditional
+        assert not dependencies[4].is_optional
+        assert "foobar" in dependencies[4].top_levels
+
+        assert dependencies[5].name == "barfoo"
+        assert not dependencies[5].is_conditional
+        assert not dependencies[5].is_optional
+        assert "barfoo" in dependencies[5].top_levels
+
+        assert dependencies[6].name == "dep"
+        assert not dependencies[6].is_conditional
+        assert not dependencies[6].is_optional
+        assert "dep" in dependencies[6].top_levels

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -27,13 +27,25 @@ def test_requirements_txt(tmp_path):
         assert spec == DependencyManagementFormat.REQUIREMENTS_TXT
 
 
-def test_pdm(tmp_path):
+def test_pdm_with_dev_dependencies(tmp_path):
+    with run_within_dir(tmp_path):
+        with open("pyproject.toml", "w") as f:
+            f.write(
+                '[project]\ndependencies=["foo"]\n[tool.pdm]\nversion = {source ='
+                ' "scm"}\n[tool.pdm.dev-dependencies]\ngroup=["bar"]'
+            )
+
+        spec = DependencySpecificationDetector().detect()
+        assert spec == DependencyManagementFormat.PDM
+
+
+def test_pdm_without_dev_dependencies(tmp_path):
     with run_within_dir(tmp_path):
         with open("pyproject.toml", "w") as f:
             f.write('[project]\ndependencies=["foo"]\n[tool.pdm]\nversion = {source = "scm"}')
 
         spec = DependencySpecificationDetector().detect()
-        assert spec == DependencyManagementFormat.PDM
+        assert spec == DependencyManagementFormat.PEP_621
 
 
 def test_pep_621(tmp_path):

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -9,7 +9,7 @@ from deptry.dependency_specification_detector import (
 from deptry.utils import run_within_dir
 
 
-def test_pyproject_toml(tmp_path):
+def test_poetry(tmp_path):
     with run_within_dir(tmp_path):
         with open("pyproject.toml", "w") as f:
             f.write('[tool.poetry.dependencies]\nfake = "10"')
@@ -34,6 +34,15 @@ def test_pdm(tmp_path):
 
         spec = DependencySpecificationDetector().detect()
         assert spec == DependencyManagementFormat.PDM
+
+
+def test_pep_621(tmp_path):
+    with run_within_dir(tmp_path):
+        with open("pyproject.toml", "w") as f:
+            f.write('[project]\ndependencies=["foo"]')
+
+        spec = DependencySpecificationDetector().detect()
+        assert spec == DependencyManagementFormat.PEP_621
 
 
 def test_both(tmp_path):
@@ -76,6 +85,7 @@ def test_raises_filenotfound_error(tmp_path):
         with pytest.raises(FileNotFoundError) as e:
             DependencySpecificationDetector(requirements_txt=("req/req.txt",)).detect()
         assert (
-            "No file called 'pyproject.toml' with a [tool.poetry.dependencies] or [tool.pdm] section or file(s)"
+            "No file called 'pyproject.toml' with a [tool.poetry.dependencies], [tool.pdm] or [project] section or"
+            " file(s)"
             in str(e)
         )


### PR DESCRIPTION
Resolves #109.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

Add support for PEP 621 dependency specification. This will ensure that modern package managers that follow PEP 621 are supported.

The implementation makes the assumption that optional dependencies under `[project.optional-dependencies]` are all non-development ones. In a follow up PR, https://github.com/fpgmaas/deptry/issues/162#issuecomment-1290501638 could be an interesting option to have to define groups that should be considered development dependencies groups.

Since PDM uses PEP 621 (with an additional logic for development dependencies), this PR also updates its dependency getter class so that it subclasses the PEP 621 one in order to avoid duplication.

The dependency specification detector is also slightly updated so that projects using PDM will only use PDM dependency getter class if they define development dependencies under `[tool.pdm.dev-dependencies]`. Otherwise, we fallback to PEP 621 dependency getter class, since there is no PDM specifics related to dependencies.