### PR TITLE
Handle CI deprecation warnings

### DIFF
--- a/.github/actions/check-docs/action.yml
+++ b/.github/actions/check-docs/action.yml
@@ -13,9 +13,9 @@ runs:
     #       check-out repo and set-up python
     #----------------------------------------------
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -34,7 +34,7 @@ runs:
     #----------------------------------------------
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: docs/.venv
         key: docs-venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/.github/actions/deploy-docs/action.yml
+++ b/.github/actions/deploy-docs/action.yml
@@ -13,9 +13,9 @@ runs:
     #       check-out repo and set-up python
     #----------------------------------------------
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -34,7 +34,7 @@ runs:
     #----------------------------------------------
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: docs/.venv
         key: docs-venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -13,9 +13,9 @@ runs:
     #       check-out repo and set-up python
     #----------------------------------------------
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Set up python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ inputs.python-version }}
     #----------------------------------------------
@@ -33,7 +33,7 @@ runs:
     #----------------------------------------------
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}

--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -61,9 +61,9 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-poetry-env
 
-      - name: Set output
+      - name: Export tag
         id: vars
-        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+        run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
 
       - name: Build and publish
         run: |


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

https://github.com/fpgmaas/deptry/actions/runs/3373976926 outputs a few deprecations warnings that this PR handles by:
- removing `set-output` usage
- bumping `actions/*` dependencies:
  - `actions/cache` changelog: [v3.0.0](https://github.com/actions/cache/releases/tag/v3.0.0)
  - `actions/checkout` changelog: [v3.0.0](https://github.com/actions/checkout/releases/tag/v3.0.0)
  - `actions/setup-python` changelogs: [v3.0.0](https://github.com/actions/setup-python/releases/tag/v3.0.0) / [v4.0.0](https://github.com/actions/setup-python/releases/tag/v3.0.0)