### PR TITLE
fix(import_parser): remove obsolete duplicated local import detection

### DIFF
--- a/deptry/import_parser.py
+++ b/deptry/import_parser.py
@@ -1,5 +1,6 @@
 import ast
 import logging
+import os
 from pathlib import Path
 from typing import List, Union
 
@@ -41,7 +42,7 @@ class ImportParser:
         except AttributeError as e:
             logging.warning(f"Warning: Parsing imports for file {str(path_to_file)} failed.")
             raise (e)
-        modules = self._remove_local_file_imports(modules, path_to_file)
+        modules = self._remove_local_file_imports(modules)
         return modules
 
     def get_imported_modules_from_str(self, file_str: str) -> List[str]:
@@ -127,19 +128,23 @@ class ImportParser:
             return chardet.detect(f.read())["encoding"]
 
     @staticmethod
-    def _remove_local_file_imports(modules: List[str], path_to_file: Path) -> List[str]:
+    def _remove_local_file_imports(modules: List[str]) -> List[str]:
         """
-        This omits imported modules from .py files in the same directory from the list of modules. consider the following directory:
+        This omits imported modules from .py files in the root directory from the list of modules.
 
-        dir
-         - foo.py
-         - bar.py
+        Considering the following structure:
+        sub_directory
+          foo.py
+          sub_bar.py
+        foo.py
+        bar.py
 
-        In this case, if foo.py any imports from bar.py such as 'from bar import x', we do not want 'bar'
-        to be included in the list of module that foo imports from.
+        In this setup:
+        - 'import bar' from foo.py will be considered as a local import.
+        - 'import sub_bar' from sub_directory/foo.py won't be considered as a local import.
+        - 'import bar' from sub_directory/foo.py will be considered as a local import.
         """
-        current_directory = path_to_file.parent
-        py_files_in_same_dir = [p.stem for p in current_directory.iterdir() if p.is_file() and p.suffix == ".py"]
+        py_files_in_same_dir = [p.stem for p in Path(os.getcwd()).iterdir() if p.is_file() and p.suffix == ".py"]
         local_files_imported = list(set(modules) & set(py_files_in_same_dir))
         if len(local_files_imported) > 0:
             logging.debug(

--- a/deptry/import_parser.py
+++ b/deptry/import_parser.py
@@ -1,6 +1,5 @@
 import ast
 import logging
-import os
 from pathlib import Path
 from typing import List, Union
 
@@ -42,7 +41,6 @@ class ImportParser:
         except AttributeError as e:
             logging.warning(f"Warning: Parsing imports for file {str(path_to_file)} failed.")
             raise (e)
-        modules = self._remove_local_file_imports(modules)
         return modules
 
     def get_imported_modules_from_str(self, file_str: str) -> List[str]:
@@ -126,30 +124,3 @@ class ImportParser:
     def _get_file_encoding(file_name: Union[str, Path]) -> str:
         with open(file_name, "rb") as f:
             return chardet.detect(f.read())["encoding"]
-
-    @staticmethod
-    def _remove_local_file_imports(modules: List[str]) -> List[str]:
-        """
-        This omits imported modules from .py files in the root directory from the list of modules.
-
-        Considering the following structure:
-        sub_directory
-          foo.py
-          sub_bar.py
-        foo.py
-        bar.py
-
-        In this setup:
-        - 'import bar' from foo.py will be considered as a local import.
-        - 'import sub_bar' from sub_directory/foo.py won't be considered as a local import.
-        - 'import bar' from sub_directory/foo.py will be considered as a local import.
-        """
-        py_files_in_same_dir = [p.stem for p in Path(os.getcwd()).iterdir() if p.is_file() and p.suffix == ".py"]
-        local_files_imported = list(set(modules) & set(py_files_in_same_dir))
-        if len(local_files_imported) > 0:
-            logging.debug(
-                f"Imports {local_files_imported} found to be imports from local .py files. Removing them from the list"
-                " of imported modules."
-            )
-            return [module for module in modules if module not in py_files_in_same_dir]
-        return modules

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -1,31 +1,24 @@
 import logging
 import sys
+from dataclasses import dataclass
 from typing import List, Optional, Set
 
 from deptry.compat import PackageNotFoundError, metadata
 from deptry.dependency import Dependency
 
 
+@dataclass
 class Module:
-    def __init__(
-        self,
-        name: str,
-        standard_library: bool = False,
-        local_module: bool = False,
-        package: Optional[str] = None,
-        top_levels: Optional[List[str]] = None,
-        dev_top_levels: Optional[List[str]] = None,
-        is_dependency: Optional[bool] = None,
-        is_dev_dependency: Optional[bool] = None,
-    ) -> None:
-        self.name = name
-        self.standard_library = standard_library
-        self.local_module = local_module
-        self.package = package
-        self.top_levels = top_levels
-        self.dev_top_levels = dev_top_levels
-        self.is_dependency = is_dependency
-        self.is_dev_dependency = is_dev_dependency
+    name: str
+    standard_library: bool = False
+    local_module: bool = False
+    package: Optional[str] = None
+    top_levels: Optional[List[str]] = None
+    dev_top_levels: Optional[List[str]] = None
+    is_dependency: Optional[bool] = None
+    is_dev_dependency: Optional[bool] = None
+
+    def __post_init__(self) -> None:
         self._log()
 
     def _log(self) -> None:

--- a/tests/issues_finder/test_misplaced_dev.py
+++ b/tests/issues_finder/test_misplaced_dev.py
@@ -6,6 +6,7 @@ from deptry.module import Module
 def test_simple():
     dependencies = [Dependency("bar")]
     modules = [Module("foo", dev_top_levels=["foo"], is_dev_dependency=True)]
+
     deps = MisplacedDevDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 1
-    assert deps[0] == "foo"
+
+    assert deps == ["foo"]

--- a/tests/issues_finder/test_missing.py
+++ b/tests/issues_finder/test_missing.py
@@ -5,19 +5,31 @@ from deptry.module import ModuleBuilder
 
 def test_simple():
     dependencies = []
-    modules = [ModuleBuilder("foobar", dependencies).build()]
+    modules = [ModuleBuilder("foobar", {"foo"}, dependencies).build()]
+
     deps = MissingDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 1
-    assert deps[0] == "foobar"
+
+    assert deps == ["foobar"]
+
+
+def test_local_module():
+    dependencies = []
+    modules = [ModuleBuilder("foobar", {"foo", "foobar"}, dependencies).build()]
+
+    deps = MissingDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
+
+    assert deps == []
 
 
 def test_simple_with_ignore():
     dependencies = []
-    modules = [ModuleBuilder("foobar", dependencies).build()]
+    modules = [ModuleBuilder("foobar", {"foo", "bar"}, dependencies).build()]
+
     deps = MissingDependenciesFinder(
         imported_modules=modules, dependencies=dependencies, ignored_modules=("foobar",)
     ).find()
-    assert len(deps) == 0
+
+    assert deps == []
 
 
 def test_no_error():
@@ -25,8 +37,9 @@ def test_no_error():
     This should run without an error, even though `foo` is not installed.
     """
 
-    dep = Dependency("foo")
-    module = ModuleBuilder("foo", [dep]).build()
+    dependencies = [Dependency("foo")]
+    module = ModuleBuilder("foo", {"bar"}, dependencies).build()
 
-    deps = MissingDependenciesFinder(imported_modules=[module], dependencies=[dep]).find()
-    assert len(deps) == 0
+    deps = MissingDependenciesFinder(imported_modules=[module], dependencies=dependencies).find()
+
+    assert deps == []

--- a/tests/issues_finder/test_obsolete.py
+++ b/tests/issues_finder/test_obsolete.py
@@ -5,19 +5,22 @@ from deptry.module import ModuleBuilder
 
 def test_simple():
     dependencies = [Dependency("click"), Dependency("toml")]
-    modules = [ModuleBuilder("click", dependencies).build()]
+    modules = [ModuleBuilder("click", {"foo"}, dependencies).build()]
+
     deps = ObsoleteDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 1
-    assert deps[0] == "toml"
+
+    assert deps == ["toml"]
 
 
 def test_simple_with_ignore():
     dependencies = [Dependency("click"), Dependency("toml")]
-    modules = [ModuleBuilder("toml", dependencies).build()]
+    modules = [ModuleBuilder("toml", {"foo"}, dependencies).build()]
+
     deps = ObsoleteDependenciesFinder(
         imported_modules=modules, dependencies=dependencies, ignored_modules=("click",)
     ).find()
-    assert len(deps) == 0
+
+    assert deps == []
 
 
 def test_top_level():
@@ -26,9 +29,11 @@ def test_top_level():
     blackd is in the top-level of black, so black should not be marked as an obsolete dependency.
     """
     dependencies = [Dependency("black")]
-    modules = [ModuleBuilder("blackd", dependencies).build()]
+    modules = [ModuleBuilder("blackd", {"foo"}, dependencies).build()]
+
     deps = ObsoleteDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 0
+
+    assert deps == []
 
 
 def test_without_top_level():
@@ -36,6 +41,8 @@ def test_without_top_level():
     Test if packages without top-level information are correctly maked as obsolete
     """
     dependencies = [Dependency("isort")]
-    modules = [ModuleBuilder("isort", dependencies).build()]
+    modules = [ModuleBuilder("isort", {"foo"}, dependencies).build()]
+
     deps = ObsoleteDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 0
+
+    assert deps == []

--- a/tests/issues_finder/test_transitive.py
+++ b/tests/issues_finder/test_transitive.py
@@ -7,16 +7,19 @@ def test_simple():
     black is in testing environment which requires platformdirs, so platformdirs should be found as transitive.
     """
     dependencies = []
-    modules = [ModuleBuilder("platformdirs", dependencies).build()]
+    modules = [ModuleBuilder("platformdirs", {"foo"}, dependencies).build()]
+
     deps = TransitiveDependenciesFinder(imported_modules=modules, dependencies=dependencies).find()
-    assert len(deps) == 1
-    assert deps[0] == "platformdirs"
+
+    assert deps == ["platformdirs"]
 
 
 def test_simple_with_ignore():
     dependencies = []
-    modules = [ModuleBuilder("foobar", dependencies).build()]
+    modules = [ModuleBuilder("foobar", {"foo"}, dependencies).build()]
+
     deps = TransitiveDependenciesFinder(
         imported_modules=modules, dependencies=dependencies, ignored_modules=("foobar",)
     ).find()
-    assert len(deps) == 0
+
+    assert deps == []

--- a/tests/test_import_parser.py
+++ b/tests/test_import_parser.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -128,27 +127,6 @@ print('嘉大')
 
         imported_modules = ImportParser().get_imported_modules_from_file(Path("file4.py"))
         assert set(imported_modules) == {"foo"}
-
-
-def test_remove_local_file_imports(tmp_path):
-    with run_within_dir(tmp_path):
-        sub_directory = tmp_path / "sub"
-        os.mkdir(sub_directory)
-
-        with open("foo.py", "w", encoding="utf-8") as f:
-            f.write("import hobbes\nimport bar\nfrom bar import x")
-
-        with open("bar.py", "w", encoding="utf-8") as f:
-            f.write("def x():\tprint('hello')")
-
-        with open(sub_directory / "foo.py", "w", encoding="utf-8") as f:
-            f.write("import hobbes\nimport bar\nimport sub_bar")
-
-        with open(sub_directory / "sub_bar.py", "w", encoding="utf-8") as f:
-            f.write("def x():\tprint('hello')")
-
-        assert ImportParser().get_imported_modules_from_file(Path("foo.py")) == ["hobbes"]
-        assert ImportParser().get_imported_modules_from_file(sub_directory / "foo.py") == ["hobbes", "sub_bar"]
 
 
 def test_import_parser_file_encodings_warning(tmp_path, caplog):

--- a/tests/test_import_parser.py
+++ b/tests/test_import_parser.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -131,13 +132,23 @@ print('嘉大')
 
 def test_remove_local_file_imports(tmp_path):
     with run_within_dir(tmp_path):
+        sub_directory = tmp_path / "sub"
+        os.mkdir(sub_directory)
+
         with open("foo.py", "w", encoding="utf-8") as f:
             f.write("import hobbes\nimport bar\nfrom bar import x")
+
         with open("bar.py", "w", encoding="utf-8") as f:
             f.write("def x():\tprint('hello')")
 
-        imported_modules = ImportParser().get_imported_modules_from_file(Path("foo.py"))
-        assert imported_modules == ["hobbes"]
+        with open(sub_directory / "foo.py", "w", encoding="utf-8") as f:
+            f.write("import hobbes\nimport bar\nimport sub_bar")
+
+        with open(sub_directory / "sub_bar.py", "w", encoding="utf-8") as f:
+            f.write("def x():\tprint('hello')")
+
+        assert ImportParser().get_imported_modules_from_file(Path("foo.py")) == ["hobbes"]
+        assert ImportParser().get_imported_modules_from_file(sub_directory / "foo.py") == ["hobbes", "sub_bar"]
 
 
 def test_import_parser_file_encodings_warning(tmp_path, caplog):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -7,22 +7,34 @@ from deptry.module import ModuleBuilder
 
 
 def test_simple_import():
-    module = ModuleBuilder("click").build()
+    module = ModuleBuilder("click", {"foo", "bar"}).build()
     assert module.package == "click"
+    assert module.standard_library is False
+    assert module.local_module is False
 
 
 def test_top_level():
     # Test if no error is raised, argument is accepted.
     dependency = Dependency("beautifulsoup4")
     dependency.top_levels = ["bs4"]
-    module = ModuleBuilder("bs4", [dependency]).build()
+    module = ModuleBuilder("bs4", {"foo", "bar"}, [dependency]).build()
     assert module.package is None
+    assert module.standard_library is False
+    assert module.local_module is False
 
 
 def test_stdlib():
-    module = ModuleBuilder("sys").build()
+    module = ModuleBuilder("sys", {"foo", "bar"}).build()
     assert module.package is None
-    assert module.standard_library
+    assert module.standard_library is True
+    assert module.local_module is False
+
+
+def test_local_module():
+    module = ModuleBuilder("click", {"foo", "click"}).build()
+    assert module.package is None
+    assert module.standard_library is False
+    assert module.local_module is True
 
 
 @pytest.mark.parametrize(
@@ -42,7 +54,7 @@ def test_stdlib():
 def test__get_stdlib_packages_supported(version_info):
     """It should not raise any error when Python version is supported."""
     with mock.patch("sys.version_info", version_info):
-        assert isinstance(ModuleBuilder("")._get_stdlib_packages(), set)
+        assert isinstance(ModuleBuilder("", set())._get_stdlib_packages(), set)
 
 
 @pytest.mark.parametrize(
@@ -61,4 +73,4 @@ def test__get_stdlib_packages_supported(version_info):
 def test__get_stdlib_packages_unsupported(version_info):
     """It should raise an error when Python version is unsupported."""
     with mock.patch("sys.version_info", version_info), pytest.raises(ValueError):
-        assert ModuleBuilder("")._get_stdlib_packages()
+        assert ModuleBuilder("", set())._get_stdlib_packages()


### PR DESCRIPTION
Resolves #171.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Update `_remove_local_file_imports` method so that it correctly considers local imports for modules in the root directory of a project.