### PR TITLE
ci: add Python version to cache key

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -36,7 +36,7 @@ runs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+        key: venv-${{ runner.os }}-${{ inputs.python-version }}-${{ hashFiles('poetry.lock') }}
 
     #----------------------------------------------
     # install dependencies if cache does not exist


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

https://github.com/fpgmaas/deptry/actions/runs/3320886881/jobs/5487809759#step:4:20 highlights that we are currently running tox under Python 3.10 regardless of the Python version sent as an input, because we share the cache key regardless of the version.