### PR TITLE
Add `pyupgrade` to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/asottile/pyupgrade
+    rev: "v3.2.0"
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+
   - repo: https://github.com/psf/black
     rev: "22.8.0"
     hooks:

--- a/deptry/cli_defaults.py
+++ b/deptry/cli_defaults.py
@@ -3,7 +3,7 @@ DEFAULTS = {
     "ignore_missing": (),
     "ignore_transitive": (),
     "ignore_misplaced_dev": (),
-    "exclude": ("venv", "\.venv", "tests", "\.git", "setup.py"),
+    "exclude": ("venv", r"\.venv", "tests", r"\.git", "setup.py"),
     "extend_exclude": (),
     "ignore_notebooks": False,
     "skip_obsolete": False,

--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -104,7 +104,7 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
 
     @staticmethod
     def _line_is_url(line: str) -> Optional[Match[str]]:
-        return re.search("^(http|https|git\+https)", line)
+        return re.search(r"^(http|https|git\+https)", line)
 
     @staticmethod
     def _extract_name_from_url(line: str) -> Optional[str]:
@@ -114,12 +114,12 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
             return match.group(1)
 
         # for url like git+https://github.com/name/python-module.git@0d6dc38d58
-        match = re.search("\/((?:(?!\/).)*?)\.git", line)
+        match = re.search(r"\/((?:(?!\/).)*?)\.git", line)
         if match:
             return match.group(1)
 
         # for url like https://github.com/urllib3/urllib3/archive/refs/tags/1.26.8.zip
-        match = re.search("\/((?:(?!\/).)*?)\/archive\/", line)
+        match = re.search(r"\/((?:(?!\/).)*?)\/archive\/", line)
         if match:
             return match.group(1)
 

--- a/deptry/notebook_import_extractor.py
+++ b/deptry/notebook_import_extractor.py
@@ -27,7 +27,7 @@ class NotebookImportExtractor:
 
     @staticmethod
     def _read_ipynb_file(path_to_ipynb: Path) -> Dict[str, Any]:
-        with open(path_to_ipynb, "r") as f:
+        with open(path_to_ipynb) as f:
             notebook: Dict[str, Any] = json.load(f)
         return notebook
 

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -27,7 +27,7 @@ class PythonFileFinder:
         py_regex = re.compile(r".*\.py$") if self.ignore_notebooks else re.compile(r".*\.py$|.*\.ipynb$")
 
         for root, dirs, files in os.walk(directory, topdown=True):
-            root_without_trailing_dotslash = re.sub("^\./", "", root)
+            root_without_trailing_dotslash = re.sub(r"^\./", "", root)
             if self.exclude and ignore_regex.match(root_without_trailing_dotslash):
                 dirs[:] = []
                 continue

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -93,7 +93,7 @@ def test_cli_with_json_output(dir_with_venv_installed):
 
         # assert that there is json output
         subprocess.run(shlex.split("poetry run deptry . -o deptry.json"), capture_output=True, text=True)
-        with open("deptry.json", "r") as f:
+        with open("deptry.json") as f:
             data = json.load(f)
         assert set(data["obsolete"]) == {"isort", "requests"}
         assert set(data["missing"]) == {"white"}

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -8,7 +8,7 @@ def test_simple(tmp_path):
     with run_within_dir(tmp_path):
         JsonWriter(json_output="output.json").write(issues={"one": "two", "three": "four"})
 
-        with open("output.json", "r") as f:
+        with open("output.json") as f:
             data = json.load(f)
 
         assert data["one"] == "two"


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Add https://github.com/asottile/pyupgrade/ to our pre-commit hooks.

The library rewrites code to newer syntax of Python versions, which will prove useful the day we drop support for Python 3.7.
A nice feature of `pyupgrade` is also https://github.com/asottile/pyupgrade/#python2-and-old-python3x-blocks, which will rewrite a conditional import whenever the Python version in the condition is not supported anymore.