### PR TITLE
Run renovate on saturdays and add renovate config check to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,3 +44,8 @@ repos:
     rev: "v1.9.0"
     hooks:
       - id: python-check-blanket-noqa
+
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: "34.24.0"
+    hooks:
+      - id: renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,6 +30,7 @@
     },
   ],
 
+  // https://docs.renovatebot.com/configuration-options/#schedule
   schedule: [
     "on saturday"
   ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,4 +29,8 @@
       datasourceTemplate: "pypi",
     },
   ],
+
+  schedule: [
+    "on saturday"
+  ]
 }


### PR DESCRIPTION
I don't think it's important to check for outdated dependencies every day, so to prevent getting notifications every day I propose to run on Saturday only.

Also added a renovate config check to the pre-commit hook.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
