### PR TITLE
refactor: use generic types instead of `typing`

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
 
 import click
 
@@ -15,10 +16,10 @@ class CommaSeparatedTupleParamType(click.ParamType):
 
     def convert(
         self,
-        value: Union[str, List[str], Tuple[str, ...]],
-        param: Optional[click.Parameter],
-        ctx: Optional[click.Context],
-    ) -> Tuple[str, ...]:
+        value: str | list[str] | tuple[str, ...],
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> tuple[str, ...]:
         if isinstance(value, str):
             return tuple(value.split(","))
         if isinstance(value, list):
@@ -189,19 +190,19 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
 )
 def deptry(
     root: Path,
-    ignore_obsolete: Tuple[str, ...],
-    ignore_missing: Tuple[str, ...],
-    ignore_transitive: Tuple[str, ...],
-    ignore_misplaced_dev: Tuple[str, ...],
+    ignore_obsolete: tuple[str, ...],
+    ignore_missing: tuple[str, ...],
+    ignore_transitive: tuple[str, ...],
+    ignore_misplaced_dev: tuple[str, ...],
     skip_obsolete: bool,
     skip_missing: bool,
     skip_transitive: bool,
     skip_misplaced_dev: bool,
-    exclude: Tuple[str, ...],
-    extend_exclude: Tuple[str, ...],
+    exclude: tuple[str, ...],
+    extend_exclude: tuple[str, ...],
     ignore_notebooks: bool,
-    requirements_txt: Tuple[str, ...],
-    requirements_txt_dev: Tuple[str, ...],
+    requirements_txt: tuple[str, ...],
+    requirements_txt_dev: tuple[str, ...],
     json_output: str,
 ) -> None:
     """Find dependency issues in your Python project.

--- a/deptry/config.py
+++ b/deptry/config.py
@@ -1,12 +1,14 @@
+from __future__ import annotations
+
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import click
 
 from deptry.utils import load_pyproject_toml
 
 
-def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: str) -> Optional[str]:
+def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: str) -> str | None:
     """
     Callback that, given a click context, overrides the default values with configuration options set in a
     pyproject.toml file.
@@ -28,7 +30,7 @@ def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Par
         logging.debug("No configuration for deptry was found in pyproject.toml.")
         return None
 
-    click_default_map: Dict[str, Any] = {}
+    click_default_map: dict[str, Any] = {}
 
     if ctx.default_map:
         click_default_map.update(ctx.default_map)

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import logging
 import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Set, Tuple
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract
@@ -28,19 +29,19 @@ from deptry.result_logger import ResultLogger
 
 @dataclass
 class Core:
-    ignore_obsolete: Tuple[str, ...]
-    ignore_missing: Tuple[str, ...]
-    ignore_transitive: Tuple[str, ...]
-    ignore_misplaced_dev: Tuple[str, ...]
+    ignore_obsolete: tuple[str, ...]
+    ignore_missing: tuple[str, ...]
+    ignore_transitive: tuple[str, ...]
+    ignore_misplaced_dev: tuple[str, ...]
     skip_obsolete: bool
     skip_missing: bool
     skip_transitive: bool
     skip_misplaced_dev: bool
-    exclude: Tuple[str, ...]
-    extend_exclude: Tuple[str, ...]
+    exclude: tuple[str, ...]
+    extend_exclude: tuple[str, ...]
     ignore_notebooks: bool
-    requirements_txt: Tuple[str, ...]
-    requirements_txt_dev: Tuple[str, ...]
+    requirements_txt: tuple[str, ...]
+    requirements_txt_dev: tuple[str, ...]
     json_output: str
 
     def run(self) -> None:
@@ -69,7 +70,7 @@ class Core:
 
         self._exit(issues)
 
-    def _find_issues(self, imported_modules: List[Module], dependencies: List[Dependency]) -> Dict[str, List[str]]:
+    def _find_issues(self, imported_modules: list[Module], dependencies: list[Dependency]) -> dict[str, list[str]]:
         result = {}
         if not self.skip_obsolete:
             result["obsolete"] = ObsoleteDependenciesFinder(imported_modules, dependencies, self.ignore_obsolete).find()
@@ -97,7 +98,7 @@ class Core:
         raise ValueError("Incorrect dependency manage format. Only poetry, pdm and requirements.txt are supported.")
 
     @staticmethod
-    def _get_local_modules() -> Set[str]:
+    def _get_local_modules() -> set[str]:
         directories = [f for f in os.listdir() if Path(f).is_dir()]
         return {subdir for subdir in directories if "__init__.py" in os.listdir(subdir)}
 
@@ -108,5 +109,5 @@ class Core:
         logging.debug("")
 
     @staticmethod
-    def _exit(issues: Dict[str, List[str]]) -> None:
+    def _exit(issues: dict[str, list[str]]) -> None:
         sys.exit(int(any(issues.values())))

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 import re
-from typing import List, Set
 
 from deptry.compat import PackageNotFoundError, metadata
 
@@ -25,7 +26,7 @@ class Dependency:
         self.found = self.find_metadata(name)
         self.top_levels = self._get_top_levels(name)
 
-    def _get_top_levels(self, name: str) -> Set[str]:
+    def _get_top_levels(self, name: str) -> set[str]:
         top_levels = []
 
         if self.found:
@@ -68,7 +69,7 @@ class Dependency:
         else:
             return " "
 
-    def _get_top_level_module_names_from_top_level_txt(self) -> List[str]:
+    def _get_top_level_module_names_from_top_level_txt(self) -> list[str]:
         """
         top-level.txt is a metadata file added by setuptools that looks as follows:
 
@@ -86,7 +87,7 @@ class Dependency:
         else:
             return []
 
-    def _get_top_level_module_names_from_record_file(self) -> List[str]:
+    def _get_top_level_module_names_from_record_file(self) -> list[str]:
         """
         Get the top-level module names from the RECORD file, whose contents usually look as follows:
 

--- a/deptry/dependency_getter/base.py
+++ b/deptry/dependency_getter/base.py
@@ -1,15 +1,16 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List
 
 from deptry.dependency import Dependency
 
 
 @dataclass
 class DependenciesExtract:
-    dependencies: List[Dependency]
-    dev_dependencies: List[Dependency]
+    dependencies: list[Dependency]
+    dev_dependencies: list[Dependency]
 
 
 @dataclass
@@ -22,7 +23,7 @@ class DependencyGetter(ABC):
         raise NotImplementedError()
 
     @staticmethod
-    def _log_dependencies(dependencies: List[Dependency], is_dev: bool = False) -> None:
+    def _log_dependencies(dependencies: list[Dependency], is_dev: bool = False) -> None:
         logging.debug(f"The project contains the following {'dev ' if is_dev else ''}dependencies:")
         for dependency in dependencies:
             logging.debug(str(dependency))

--- a/deptry/dependency_getter/pdm.py
+++ b/deptry/dependency_getter/pdm.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import Dict, List
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract
@@ -23,7 +24,7 @@ class PDMDependencyGetter(PEP621DependencyGetter):
         return DependenciesExtract(pep_621_dependencies_extract.dependencies, dev_dependencies)
 
     @classmethod
-    def _get_pdm_dev_dependencies(cls) -> List[Dependency]:
+    def _get_pdm_dev_dependencies(cls) -> list[Dependency]:
         """
         Try to get development dependencies from pyproject.toml, which with PDM are specified as:
 
@@ -39,9 +40,9 @@ class PDMDependencyGetter(PEP621DependencyGetter):
         """
         pyproject_data = load_pyproject_toml()
 
-        dev_dependency_strings: List[str] = []
+        dev_dependency_strings: list[str] = []
         try:
-            dev_dependencies_dict: Dict[str, str] = pyproject_data["tool"]["pdm"]["dev-dependencies"]
+            dev_dependencies_dict: dict[str, str] = pyproject_data["tool"]["pdm"]["dev-dependencies"]
             for deps in dev_dependencies_dict.values():
                 dev_dependency_strings += deps
         except KeyError:

--- a/deptry/dependency_getter/pep_621.py
+++ b/deptry/dependency_getter/pep_621.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import itertools
 import re
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
@@ -17,13 +18,13 @@ class PEP621DependencyGetter(DependencyGetter):
         return DependenciesExtract(dependencies, [])
 
     @classmethod
-    def _get_dependencies(cls) -> List[Dependency]:
+    def _get_dependencies(cls) -> list[Dependency]:
         pyproject_data = load_pyproject_toml()
-        dependency_strings: List[str] = pyproject_data["project"]["dependencies"]
+        dependency_strings: list[str] = pyproject_data["project"]["dependencies"]
         return cls._extract_pep_508_dependencies(dependency_strings)
 
     @classmethod
-    def _get_optional_dependencies(cls) -> Dict[str, List[Dependency]]:
+    def _get_optional_dependencies(cls) -> dict[str, list[Dependency]]:
         pyproject_data = load_pyproject_toml()
 
         return {
@@ -32,7 +33,7 @@ class PEP621DependencyGetter(DependencyGetter):
         }
 
     @classmethod
-    def _extract_pep_508_dependencies(cls, dependencies: List[str]) -> List[Dependency]:
+    def _extract_pep_508_dependencies(cls, dependencies: list[str]) -> list[Dependency]:
         extracted_dependencies = []
 
         for spec in dependencies:
@@ -54,7 +55,7 @@ class PEP621DependencyGetter(DependencyGetter):
         return ";" in dependency_specification
 
     @staticmethod
-    def _find_dependency_name_in(spec: str) -> Optional[str]:
+    def _find_dependency_name_in(spec: str) -> str | None:
         match = re.search("[a-zA-Z0-9-_]+", spec)
         if match:
             return match.group(0)

--- a/deptry/dependency_getter/poetry.py
+++ b/deptry/dependency_getter/poetry.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import contextlib
 from dataclasses import dataclass
-from typing import Any, Dict, List, Union
+from typing import Any
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
@@ -21,13 +23,13 @@ class PoetryDependencyGetter(DependencyGetter):
         return DependenciesExtract(dependencies, dev_dependencies)
 
     @classmethod
-    def _get_poetry_dependencies(cls) -> List[Dependency]:
+    def _get_poetry_dependencies(cls) -> list[Dependency]:
         pyproject_data = load_pyproject_toml()
-        dependencies: Dict[str, Any] = pyproject_data["tool"]["poetry"]["dependencies"]
+        dependencies: dict[str, Any] = pyproject_data["tool"]["poetry"]["dependencies"]
         return cls._get_dependencies(dependencies)
 
     @classmethod
-    def _get_poetry_dev_dependencies(cls) -> List[Dependency]:
+    def _get_poetry_dev_dependencies(cls) -> list[Dependency]:
         """
         These can be either under;
 
@@ -36,7 +38,7 @@ class PoetryDependencyGetter(DependencyGetter):
 
         or both.
         """
-        dependencies: Dict[str, str] = {}
+        dependencies: dict[str, str] = {}
         pyproject_data = load_pyproject_toml()
 
         with contextlib.suppress(KeyError):
@@ -48,7 +50,7 @@ class PoetryDependencyGetter(DependencyGetter):
         return cls._get_dependencies(dependencies)
 
     @classmethod
-    def _get_dependencies(cls, poetry_dependencies: Dict[str, Any]) -> List[Dependency]:
+    def _get_dependencies(cls, poetry_dependencies: dict[str, Any]) -> list[Dependency]:
         dependencies = []
         for dep, spec in poetry_dependencies.items():
             # dep is the dependency name, spec is the version specification, e.g. "^0.2.2" or {"*", optional = true}
@@ -60,11 +62,11 @@ class PoetryDependencyGetter(DependencyGetter):
         return dependencies
 
     @staticmethod
-    def _is_optional(spec: Union[str, Dict[str, Any]]) -> bool:
+    def _is_optional(spec: str | dict[str, Any]) -> bool:
         # if of the shape `isodate = {version = "*", optional = true}` mark as optional`
         return bool(isinstance(spec, dict) and spec.get("optional"))
 
     @staticmethod
-    def _is_conditional(spec: Union[str, Dict[str, Any]]) -> bool:
+    def _is_conditional(spec: str | dict[str, Any]) -> bool:
         # if of the shape `tomli = { version = "^2.0.1", python = "<3.11" }`, mark as conditional.
         return isinstance(spec, dict) and "python" in spec and "version" in spec

--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import itertools
 import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import List, Match, Optional, Tuple
+from typing import Match
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
@@ -13,8 +15,8 @@ from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
 class RequirementsTxtDependencyGetter(DependencyGetter):
     """Extract dependencies from requirements.txt files."""
 
-    requirements_txt: Tuple[str, ...] = ("requirements.txt",)
-    requirements_txt_dev: Tuple[str, ...] = ("dev-requirements.txt", "requirements-dev.txt")
+    requirements_txt: tuple[str, ...] = ("requirements.txt",)
+    requirements_txt_dev: tuple[str, ...] = ("dev-requirements.txt", "requirements-dev.txt")
 
     def get(self) -> DependenciesExtract:
         dependencies = list(
@@ -36,7 +38,7 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
 
         return DependenciesExtract(dependencies, dev_dependencies)
 
-    def _scan_for_dev_requirements_files(self) -> List[str]:
+    def _scan_for_dev_requirements_files(self) -> list[str]:
         """
         Check if any of the files passed as requirements_txt_dev exist, and if so; return them.
         """
@@ -45,7 +47,7 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
             logging.debug(f"Found files with development requirements! {dev_requirements_files}")
         return dev_requirements_files
 
-    def _get_dependencies_from_requirements_file(self, file_name: str, is_dev: bool = False) -> List[Dependency]:
+    def _get_dependencies_from_requirements_file(self, file_name: str, is_dev: bool = False) -> list[Dependency]:
         logging.debug(f"Scanning {file_name} for {'dev ' if is_dev else ''}dependencies")
         dependencies = []
 
@@ -59,7 +61,7 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
 
         return dependencies
 
-    def _extract_dependency_from_line(self, line: str) -> Optional[Dependency]:
+    def _extract_dependency_from_line(self, line: str) -> Dependency | None:
         """
         Extract a dependency from a single line of a requirements.txt file.
         """
@@ -74,7 +76,7 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
         else:
             return None
 
-    def _find_dependency_name_in(self, line: str) -> Optional[str]:
+    def _find_dependency_name_in(self, line: str) -> str | None:
         """
         Find the dependency name of a dependency specified according to the pip-standards for requirement.txt
         """
@@ -103,11 +105,11 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
         return ";" in line
 
     @staticmethod
-    def _line_is_url(line: str) -> Optional[Match[str]]:
+    def _line_is_url(line: str) -> Match[str] | None:
         return re.search(r"^(http|https|git\+https)", line)
 
     @staticmethod
-    def _extract_name_from_url(line: str) -> Optional[str]:
+    def _extract_name_from_url(line: str) -> str | None:
         # Try to find egg, for url like git+https://github.com/xxxxx/package@xxxxx#egg=package
         match = re.search("egg=([a-zA-Z0-9-_]*)", line)
         if match:

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import logging
 import os
 from enum import Enum
-from typing import Tuple
 
 from deptry.utils import load_pyproject_toml
 
@@ -23,7 +24,7 @@ class DependencySpecificationDetector:
 
     """
 
-    def __init__(self, requirements_txt: Tuple[str, ...] = ("requirements.txt",)) -> None:
+    def __init__(self, requirements_txt: tuple[str, ...] = ("requirements.txt",)) -> None:
         self.requirements_txt = requirements_txt
 
     def detect(self) -> DependencyManagementFormat:

--- a/deptry/imports/extract.py
+++ b/deptry/imports/extract.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import itertools
 import logging
 from pathlib import Path
-from typing import List, Set
 
 from deptry.imports.extractors import NotebookImportExtractor, PythonImportExtractor
 
@@ -9,7 +10,7 @@ from deptry.imports.extractors import NotebookImportExtractor, PythonImportExtra
 _FILTERED_OUT_MODULES = {"setuptools"}
 
 
-def get_imported_modules_for_list_of_files(list_of_files: List[Path]) -> List[str]:
+def get_imported_modules_for_list_of_files(list_of_files: list[Path]) -> list[str]:
     logging.info(f"Scanning {len(list_of_files)} files...")
 
     unique_modules = set(itertools.chain.from_iterable(get_imported_modules_from_file(file) for file in list_of_files))
@@ -20,7 +21,7 @@ def get_imported_modules_for_list_of_files(list_of_files: List[Path]) -> List[st
     return filtered_modules
 
 
-def get_imported_modules_from_file(path_to_file: Path) -> Set[str]:
+def get_imported_modules_from_file(path_to_file: Path) -> set[str]:
     logging.debug(f"Scanning {path_to_file}...")
 
     if path_to_file.suffix == ".ipynb":
@@ -33,7 +34,7 @@ def get_imported_modules_from_file(path_to_file: Path) -> Set[str]:
     return modules
 
 
-def _filter_out_modules(modules: Set[str]) -> Set[str]:
+def _filter_out_modules(modules: set[str]) -> set[str]:
     for filtered_out_module in _FILTERED_OUT_MODULES:
         if filtered_out_module in modules:
             logging.debug(f"Found module {filtered_out_module} to be imported, omitting from the list of modules.")

--- a/deptry/issues_finder/base.py
+++ b/deptry/issues_finder/base.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import List, Tuple
 
 from deptry.dependency import Dependency
 from deptry.module import Module
@@ -10,11 +11,11 @@ from deptry.module import Module
 class IssuesFinder(ABC):
     """Base class for all issues finders."""
 
-    imported_modules: List[Module]
-    dependencies: List[Dependency]
-    ignored_modules: Tuple[str, ...] = ()
+    imported_modules: list[Module]
+    dependencies: list[Dependency]
+    ignored_modules: tuple[str, ...] = ()
 
     @abstractmethod
-    def find(self) -> List[str]:
+    def find(self) -> list[str]:
         """Find issues about dependencies."""
         raise NotImplementedError()

--- a/deptry/issues_finder/misplaced_dev.py
+++ b/deptry/issues_finder/misplaced_dev.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
 
 from deptry.issues_finder.base import IssuesFinder
 from deptry.module import Module
@@ -15,7 +16,7 @@ class MisplacedDevDependenciesFinder(IssuesFinder):
     This is the case for any development dependency encountered, since files solely used for development purposes should be excluded from scanning.
     """
 
-    def find(self) -> List[str]:
+    def find(self) -> list[str]:
         """
         In this function, we use 'corresponding_package_name' instead of module.package, since it can happen that a
         development dependency is not installed, but it's still found to be used in the codebase, due to simple name matching.
@@ -43,7 +44,7 @@ class MisplacedDevDependenciesFinder(IssuesFinder):
         logging.debug(f"Dependency '{corresponding_package_name}' marked as a misplaced development dependency.")
         return True
 
-    def _get_package_name(self, module: Module) -> Optional[str]:
+    def _get_package_name(self, module: Module) -> str | None:
         if module.package:
             return module.package
         if module.dev_top_levels:

--- a/deptry/issues_finder/missing.py
+++ b/deptry/issues_finder/missing.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import List
 
 from deptry.issues_finder.base import IssuesFinder
 from deptry.module import Module
@@ -12,7 +13,7 @@ class MissingDependenciesFinder(IssuesFinder):
     Given a list of imported modules and a list of project dependencies, determine which ones are missing.
     """
 
-    def find(self) -> List[str]:
+    def find(self) -> list[str]:
         logging.debug("\nScanning for missing dependencies...")
         missing_dependencies = []
 

--- a/deptry/issues_finder/obsolete.py
+++ b/deptry/issues_finder/obsolete.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import List
 
 from deptry.dependency import Dependency
 from deptry.issues_finder.base import IssuesFinder
@@ -18,7 +19,7 @@ class ObsoleteDependenciesFinder(IssuesFinder):
     but if this is imported, the associated dependency `matplotlib` is not obsolete, even if `matplotlib` itself is not imported anywhere.
     """
 
-    def find(self) -> List[str]:
+    def find(self) -> list[str]:
         logging.debug("\nScanning for obsolete dependencies...")
         obsolete_dependencies = []
         for dependency in self.dependencies:

--- a/deptry/issues_finder/transitive.py
+++ b/deptry/issues_finder/transitive.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import List, cast
+from typing import cast
 
 from deptry.issues_finder.base import IssuesFinder
 from deptry.module import Module
@@ -19,7 +21,7 @@ class TransitiveDependenciesFinder(IssuesFinder):
     Then it must be a transitive dependency.
     """
 
-    def find(self) -> List[str]:
+    def find(self) -> list[str]:
         logging.debug("\nScanning for transitive dependencies...")
         transitive_dependencies = []
 

--- a/deptry/json_writer.py
+++ b/deptry/json_writer.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import json
-from typing import Dict, List
 
 
 class JsonWriter:
@@ -13,6 +14,6 @@ class JsonWriter:
     def __init__(self, json_output: str) -> None:
         self.json_output = json_output
 
-    def write(self, issues: Dict[str, List[str]]) -> None:
+    def write(self, issues: dict[str, list[str]]) -> None:
         with open(self.json_output, "w", encoding="utf-8") as f:
             json.dump(issues, f, ensure_ascii=False, indent=4)

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import logging
 import sys
 from dataclasses import dataclass
-from typing import List, Optional, Set
 
 from deptry.compat import PackageNotFoundError, metadata
 from deptry.dependency import Dependency
@@ -12,11 +13,11 @@ class Module:
     name: str
     standard_library: bool = False
     local_module: bool = False
-    package: Optional[str] = None
-    top_levels: Optional[List[str]] = None
-    dev_top_levels: Optional[List[str]] = None
-    is_dependency: Optional[bool] = None
-    is_dev_dependency: Optional[bool] = None
+    package: str | None = None
+    top_levels: list[str] | None = None
+    dev_top_levels: list[str] | None = None
+    is_dependency: bool | None = None
+    is_dev_dependency: bool | None = None
 
     def __post_init__(self) -> None:
         self._log()
@@ -37,9 +38,9 @@ class ModuleBuilder:
     def __init__(
         self,
         name: str,
-        local_modules: Set[str],
-        dependencies: Optional[List[Dependency]] = None,
-        dev_dependencies: Optional[List[Dependency]] = None,
+        local_modules: set[str],
+        dependencies: list[Dependency] | None = None,
+        dev_dependencies: list[Dependency] | None = None,
     ) -> None:
         """
         Create a Module object that represents an imported module.
@@ -81,7 +82,7 @@ class ModuleBuilder:
             is_dev_dependency=is_dev_dependency,
         )
 
-    def _get_package_name_from_metadata(self) -> Optional[str]:
+    def _get_package_name_from_metadata(self) -> str | None:
         """
         Most packages simply have a field called "Name" in their metadata. This method extracts that field.
         """
@@ -91,7 +92,7 @@ class ModuleBuilder:
         except PackageNotFoundError:
             return None
 
-    def _get_corresponding_top_levels_from(self, dependencies: List[Dependency]) -> List[str]:
+    def _get_corresponding_top_levels_from(self, dependencies: list[Dependency]) -> list[str]:
         """
         Not all modules have associated metadata. e.g. `mpl_toolkits` from `matplotlib` has no metadata. However, it is in the
         top-level module names of package matplotlib. This function extracts all dependencies which have this module in their top-level module names.
@@ -107,7 +108,7 @@ class ModuleBuilder:
         return self.name in self._get_stdlib_packages()
 
     @staticmethod
-    def _get_stdlib_packages() -> Set[str]:
+    def _get_stdlib_packages() -> set[str]:
         if sys.version_info[:2] == (3, 7):
             from deptry.stdlibs.py37 import stdlib
         elif sys.version_info[:2] == (3, 8):
@@ -132,14 +133,14 @@ class ModuleBuilder:
         """
         return self.name in self.local_modules
 
-    def _has_matching_dependency(self, package: Optional[str], top_levels: List[str]) -> bool:
+    def _has_matching_dependency(self, package: str | None, top_levels: list[str]) -> bool:
         """
         Check if this module is provided by a listed dependency. This is the case if either the package name that was found in the metadata is
         listed as a dependency, or if the we found a top-level module name match earlier.
         """
         return package and (package in [dep.name for dep in self.dependencies]) or len(top_levels) > 0
 
-    def _has_matching_dev_dependency(self, package: Optional[str], dev_top_levels: List[str]) -> bool:
+    def _has_matching_dev_dependency(self, package: str | None, dev_top_levels: list[str]) -> bool:
         """
         Same as _has_matching_dependency, but for development dependencies.
         """

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import re
 from pathlib import Path
-from typing import List, Tuple
 
 
 class PythonFileFinder:
@@ -14,11 +15,11 @@ class PythonFileFinder:
         ignore_notebooks: If ignore_notebooks is set to True, .ipynb files are ignored and only .py files are returned.
     """
 
-    def __init__(self, exclude: Tuple[str, ...], ignore_notebooks: bool = False) -> None:
+    def __init__(self, exclude: tuple[str, ...], ignore_notebooks: bool = False) -> None:
         self.exclude = exclude
         self.ignore_notebooks = ignore_notebooks
 
-    def get_all_python_files_in(self, directory: Path) -> List[Path]:
+    def get_all_python_files_in(self, directory: Path) -> list[Path]:
         logging.debug("Collecting Python files to scan...")
 
         all_py_files = []

--- a/deptry/result_logger.py
+++ b/deptry/result_logger.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Dict, List
 
 
 class ResultLogger:
@@ -7,7 +8,7 @@ class ResultLogger:
     Display the issues to the user, and return exit-status 0 or 1 depending on if any issues were found.
     """
 
-    def __init__(self, issues: Dict[str, List[str]]) -> None:
+    def __init__(self, issues: dict[str, list[str]]) -> None:
         self.issues = issues
 
     def log_and_exit(self) -> None:
@@ -33,14 +34,14 @@ class ResultLogger:
         else:
             logging.info(f"There were {number} dependency issues found.")
 
-    def _log_obsolete_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
+    def _log_obsolete_dependencies(self, dependencies: list[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(f"The project contains obsolete dependencies:\n{sep}{sep.join(sorted(dependencies))}\n")
         logging.info(
             """Consider removing them from your project's dependencies. If a package is used for development purposes, you should add it to your development dependencies instead."""
         )
 
-    def _log_missing_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
+    def _log_missing_dependencies(self, dependencies: list[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
             "There are dependencies missing from the project's list of"
@@ -48,7 +49,7 @@ class ResultLogger:
         )
         logging.info("""Consider adding them to your project's dependencies. """)
 
-    def _log_transitive_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
+    def _log_transitive_dependencies(self, dependencies: list[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
             "There are transitive dependencies that should be explicitly defined as"
@@ -56,7 +57,7 @@ class ResultLogger:
         )
         logging.info("""They are currently imported but not specified directly as your project's dependencies.""")
 
-    def _log_misplaced_develop_dependencies(self, dependencies: List[str], sep: str = "\n\t") -> None:
+    def _log_misplaced_develop_dependencies(self, dependencies: list[str], sep: str = "\n\t") -> None:
         logging.info("\n-----------------------------------------------------\n")
         logging.info(
             "There are imported modules from development dependencies"

--- a/deptry/utils.py
+++ b/deptry/utils.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import os
 import sys
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, Generator
+from typing import Any, Generator
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -33,7 +35,7 @@ def run_within_dir(path: Path) -> Generator[None, None, None]:
         os.chdir(oldpwd)
 
 
-def load_pyproject_toml(pyproject_toml_path: str = PYPROJECT_TOML_PATH) -> Dict[str, Any]:
+def load_pyproject_toml(pyproject_toml_path: str = PYPROJECT_TOML_PATH) -> dict[str, Any]:
     try:
         with Path(pyproject_toml_path).open("rb") as pyproject_file:
             return tomllib.load(pyproject_file)

--- a/tests/test_python_file_finder.py
+++ b/tests/test_python_file_finder.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Dict, List
 
 from deptry.python_file_finder import PythonFileFinder
 from deptry.utils import run_within_dir
 
 
-def create_files_from_list_of_dicts(paths: List[Dict[str, str]]) -> None:
+def create_files_from_list_of_dicts(paths: list[dict[str, str]]) -> None:
     """
     Takes as input an argument paths, which is a list of dicts. Each dict should have two keys;
     'dir' to denote a directory and 'file' to denote the file name. This function creates all files


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Since [PEP 585](https://peps.python.org/pep-0585/) implemented in Python 3.9, generic types can be used for type annotations in replacement of their counterparts in `typing` module.

`deptry` supports `Python >= 3.7`, but thanks to [`from __future__ import annotations`](https://peps.python.org/pep-0585/#implementation), it's possible to use those generic types on 3.7+.