### PR TITLE
Use `ruff` for import sorting and add more rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,14 +20,8 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/isort
-    rev: "5.10.1"
-    hooks:
-      - id: isort
-
-  # Temporarily run both ruff and flake8, to see if we are satisfied with ruff so it can replace flake8.
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.172
+    rev: "v0.0.174"
     hooks:
       - id: ruff
 

--- a/deptry/compat.py
+++ b/deptry/compat.py
@@ -4,7 +4,7 @@ if sys.version_info >= (3, 8):
     import importlib.metadata as metadata
     from importlib.metadata import PackageNotFoundError
 else:
-    import importlib_metadata as metadata  # noqa: F401
-    from importlib_metadata import PackageNotFoundError  # noqa: F401
+    import importlib_metadata as metadata
+    from importlib_metadata import PackageNotFoundError
 
 __all__ = ("metadata", "PackageNotFoundError")

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -12,10 +12,7 @@ from deptry.dependency_getter.pdm import PDMDependencyGetter
 from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
 from deptry.dependency_getter.poetry import PoetryDependencyGetter
 from deptry.dependency_getter.requirements_txt import RequirementsTxtDependencyGetter
-from deptry.dependency_specification_detector import (
-    DependencyManagementFormat,
-    DependencySpecificationDetector,
-)
+from deptry.dependency_specification_detector import DependencyManagementFormat, DependencySpecificationDetector
 from deptry.imports.extract import get_imported_modules_for_list_of_files
 from deptry.issues_finder.misplaced_dev import MisplacedDevDependenciesFinder
 from deptry.issues_finder.missing import MissingDependenciesFinder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ target-version = "py37"
 line-length = 120
 select = [
     # pycodestyle
-    "E",
+    "E", "W",
     # pyflakes
     "F",
     # mccabe
@@ -107,6 +107,10 @@ select = [
     "C4",
     # isort
     "I",
+    # flake8-bugbear
+    "B",
+    # ruff
+    "RUF",
 ]
 ignore = [
     # LineTooLong

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,6 @@ skip_empty = true
 branch = true
 source = ["deptry"]
 
-[tool.isort]
-profile = "black"
-
 [tool.mypy]
 files = ["deptry", "scripts", "tests"]
 exclude = ["tests/data"]
@@ -97,13 +94,24 @@ ignore_missing = ["tomllib"]
 deptry = "deptry.cli:deptry"
 
 [tool.ruff]
+target-version = "py37"
 line-length = 120
-
-select = ["E", "F", "C", "B"]
-
-# PEP-8 The following are ignored:
-# E731 do not assign a lambda expression, use a def
-# E501 line too long
-ignore = ["E731", "E501"]
-
+select = [
+    # pycodestyle
+    "E",
+    # pyflakes
+    "F",
+    # mccabe
+    "C90",
+    # flake8-comprehensions
+    "C4",
+    # isort
+    "I",
+]
+ignore = [
+    # LineTooLong
+    "E501",
+    # DoNotAssignLambda
+    "E731",
+]
 extend-exclude = ["tests/data/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ deptry = "deptry.cli:deptry"
 [tool.ruff]
 target-version = "py37"
 line-length = 120
+fix = true
 select = [
     # pycodestyle
     "E", "W",

--- a/tests/imports/test_extract.py
+++ b/tests/imports/test_extract.py
@@ -8,10 +8,7 @@ from unittest import mock
 import pytest
 from _pytest.logging import LogCaptureFixture
 
-from deptry.imports.extract import (
-    get_imported_modules_for_list_of_files,
-    get_imported_modules_from_file,
-)
+from deptry.imports.extract import get_imported_modules_for_list_of_files, get_imported_modules_from_file
 from deptry.utils import run_within_dir
 
 

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -3,10 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from deptry.dependency_specification_detector import (
-    DependencyManagementFormat,
-    DependencySpecificationDetector,
-)
+from deptry.dependency_specification_detector import DependencyManagementFormat, DependencySpecificationDetector
 from deptry.utils import run_within_dir
 
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

`ruff` [can replace `isort`](https://github.com/charliermarsh/ruff#how-does-ruffs-import-sorting-compare-to-isort) for dependency sorting. Since we already have `ruff` running in `pre-commit`, I thought it could be a good idea to fully replace `isort` and rely on `ruff` for import sorting.

The PR also enables a few more rules, to better match what we have in `flake8`. There are still rules that we use through `flake8` plugins that are not yet implemented in `ruff`, so it might be a bit early to fully replace `flake8`.

Finally, the PR adds `fix = true` to `ruff`'s configuration in order to autofix the rules that can be autofixed.