### PR TITLE
chore: move `renovate-config-validator` to GH Actions

### DIFF
--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -1,0 +1,17 @@
+name: validate-renovate-config
+
+on:
+  pull_request:
+    paths: [renovate.json5]
+  push:
+    branches: [main]
+
+jobs:
+  validate-renovate-config:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18" # renovate: datasource=node depName=node versioning=node
+      - run: npx -p renovate renovate-config-validator

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,8 +44,3 @@ repos:
     rev: "v1.9.0"
     hooks:
       - id: python-check-blanket-noqa
-
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: "34.54.0"
-    hooks:
-      - id: renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,8 +7,6 @@
     "config:base",
     // https://docs.renovatebot.com/presets-default/#enableprecommit
     ":enablePreCommit",
-    // https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly
-    ":maintainLockFilesWeekly",
     // https://docs.renovatebot.com/presets-default/#prhourlylimitnone
     ":prHourlyLimitNone",
     // https://docs.renovatebot.com/presets-default/#rebasestaleprs
@@ -17,6 +15,15 @@
 
   // https://docs.renovatebot.com/configuration-options/#labels
   labels: ["dependencies"],
+
+  // https://docs.renovatebot.com/configuration-options/#schedule
+  schedule: ["on saturday"],
+
+  // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: ["on saturday"],
+  },
 
   // https://docs.renovatebot.com/configuration-options/#regexmanagers
   regexManagers: [
@@ -29,9 +36,4 @@
       datasourceTemplate: "pypi",
     },
   ],
-
-  // https://docs.renovatebot.com/configuration-options/#schedule
-  schedule: [
-    "on saturday"
-  ]
 }


### PR DESCRIPTION
**PR Checklist**

-   [ ] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Most of the contributors won't ever update `renovate` configuration, yet the `pre-commit` hook takes quite some time to install locally (at least for me).

So instead of running it through `pre-commit`, this PR moves the workflow to a dedicated GitHub Actions workflow, similarly to the one we have for `codecov` configuration.

The PR also updates the schedule for lock file maintenance, so it runs on Saturday, same as the other updates, instead of Monday (which also allows validating the changes in the PR, to confirm that [the workflow works correctly](https://github.com/fpgmaas/deptry/actions/runs/3669978657/jobs/6204194371#step:4:10)).