### PR TITLE
ci: fix `tox` workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install tox
-        run: python -m pip install tox-gh-actions==3.0.0
+        run: python -m pip install "tox-gh-actions==3.0.0" # renovate: pep440-python-dependency
 
       - name: Test with tox
         run: tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,9 +56,7 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
 
       - name: Install tox
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+        run: python -m pip install tox-gh-actions==3.0.0
 
       - name: Test with tox
         run: tox

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,7 +29,7 @@
   regexManagers: [
     {
       description: "Update PEP 440 Python dependencies",
-      fileMatch: ["^\\.pre-commit-config\\.yaml$"],
+      fileMatch: ["^.+\\.ya?ml$"],
       matchStrings: [
         '"(?<depName>[\\w-]+)(?<currentValue>.+?)",?[[:blank:]]+#[[:blank:]]*renovate: pep440-python-dependency\\s',
       ],

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,7 @@ python =
 
 [testenv]
 passenv = PYTHON_VERSION
-whitelist_externals = poetry
+allowlist_externals = poetry
 commands =
     poetry install -v
     pytest --doctest-modules tests --cov --cov-config=pyproject.toml --cov-report=xml


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

`tox` workflow is currently broken because we don't pin a specific version of `tox-gh-actions`, and a new major version was released yesterday (https://github.com/ymyzk/tox-gh-actions/releases/tag/v3.0.0).

This made us automatically pick up `tox>=4`, which removed `whitelist_externals` option in favour of `allowlist_externals` (https://github.com/tox-dev/tox/releases/tag/4.0.0rc4).

So the PR updates the parameter used, and updates the installation of `tox-gh-actions` to pin a specific version, as well as hinting Renovate on it, so we can still benefit from regular updates while facilitating build reproducibility.

It also removes the installation of `tox` which is useless, as `tox-gh-actions` already depend on [one specific major version of `tox`](https://github.com/ymyzk/tox-gh-actions/blob/v3.0.0/setup.cfg#L44-L45). We can even see in the previously working build that [we installed 4.x.y](https://github.com/fpgmaas/deptry/actions/runs/3719666563/jobs/6308663171#step:6:16), but then [went back to 3.x.y](https://github.com/fpgmaas/deptry/actions/runs/3719666563/jobs/6308663171#step:6:42) because `tox-gh-actions<3` didn't accept `tox>=4`.