### PR TITLE
perf(core): only load local modules once

### DIFF
--- a/deptry/core.py
+++ b/deptry/core.py
@@ -51,9 +51,11 @@ class Core:
             exclude=self.exclude + self.extend_exclude, ignore_notebooks=self.ignore_notebooks
         ).get_all_python_files_in(Path("."))
 
+        local_modules = self._get_local_modules()
+
         imported_modules = [
             ModuleBuilder(
-                mod, self._get_local_modules(), dependencies_extract.dependencies, dependencies_extract.dev_dependencies
+                mod, local_modules, dependencies_extract.dependencies, dependencies_extract.dev_dependencies
             ).build()
             for mod in get_imported_modules_for_list_of_files(all_python_files)
         ]


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Local modules retrieval is currently done multiple times, as it's done in a for loop. This PR makes sure that it's only done once, greatly reducing the run time on big projects.