### PR TITLE
Expose and handle `--config` argument

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -8,7 +8,6 @@ import click
 from deptry.compat import metadata
 from deptry.config import read_configuration_from_pyproject_toml
 from deptry.core import Core
-from deptry.utils import PYPROJECT_TOML_PATH
 
 
 class CommaSeparatedTupleParamType(click.ParamType):
@@ -56,6 +55,14 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     expose_value=False,
     is_eager=True,
     callback=configure_logger,
+)
+@click.option(
+    "--config",
+    type=click.Path(path_type=Path),
+    is_eager=True,
+    callback=read_configuration_from_pyproject_toml,
+    help="Path to the pyproject.toml file to read configuration from.",
+    default="pyproject.toml",
 )
 @click.option(
     "--skip-obsolete",
@@ -178,17 +185,9 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     help="""If specified, a summary of the dependency issues found will be written to the output location specified. e.g. `deptry . -o deptry.json`""",
     show_default=True,
 )
-@click.option(
-    "--config",
-    type=click.Path(),
-    is_eager=True,
-    callback=read_configuration_from_pyproject_toml,
-    help="Path to the pyproject.toml file to read configuration from.",
-    default=PYPROJECT_TOML_PATH,
-    expose_value=False,
-)
 def deptry(
     root: Path,
+    config: Path,
     ignore_obsolete: tuple[str, ...],
     ignore_missing: tuple[str, ...],
     ignore_transitive: tuple[str, ...],
@@ -213,6 +212,7 @@ def deptry(
 
     Core(
         root=root,
+        config=config,
         ignore_obsolete=ignore_obsolete,
         ignore_missing=ignore_missing,
         ignore_transitive=ignore_transitive,

--- a/deptry/config.py
+++ b/deptry/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import Any
 
 import click
@@ -8,7 +9,7 @@ import click
 from deptry.utils import load_pyproject_toml
 
 
-def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: str) -> str | None:
+def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: Path) -> Path | None:
     """
     Callback that, given a click context, overrides the default values with configuration options set in a
     pyproject.toml file.
@@ -22,13 +23,13 @@ def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Par
         pyproject_data = load_pyproject_toml(value)
     except FileNotFoundError:
         logging.debug("No pyproject.toml file to read configuration from.")
-        return None
+        return value
 
     try:
         deptry_toml_config = pyproject_data["tool"]["deptry"]
     except KeyError:
         logging.debug("No configuration for deptry was found in pyproject.toml.")
-        return None
+        return value
 
     click_default_map: dict[str, Any] = {}
 

--- a/deptry/dependency_getter/base.py
+++ b/deptry/dependency_getter/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from pathlib import Path
 
 from deptry.dependency import Dependency
 
@@ -16,6 +17,8 @@ class DependenciesExtract:
 @dataclass
 class DependencyGetter(ABC):
     """Base class for all dependency getter."""
+
+    config: Path
 
     @abstractmethod
     def get(self) -> DependenciesExtract:

--- a/deptry/dependency_getter/pdm.py
+++ b/deptry/dependency_getter/pdm.py
@@ -23,8 +23,7 @@ class PDMDependencyGetter(PEP621DependencyGetter):
 
         return DependenciesExtract(pep_621_dependencies_extract.dependencies, dev_dependencies)
 
-    @classmethod
-    def _get_pdm_dev_dependencies(cls) -> list[Dependency]:
+    def _get_pdm_dev_dependencies(self) -> list[Dependency]:
         """
         Try to get development dependencies from pyproject.toml, which with PDM are specified as:
 
@@ -38,7 +37,7 @@ class PDMDependencyGetter(PEP621DependencyGetter):
             "tox-pdm>=0.5",
         ]
         """
-        pyproject_data = load_pyproject_toml()
+        pyproject_data = load_pyproject_toml(self.config)
 
         dev_dependency_strings: list[str] = []
         try:
@@ -48,4 +47,4 @@ class PDMDependencyGetter(PEP621DependencyGetter):
         except KeyError:
             logging.debug("No section [tool.pdm.dev-dependencies] found in pyproject.toml")
 
-        return cls._extract_pep_508_dependencies(dev_dependency_strings)
+        return self._extract_pep_508_dependencies(dev_dependency_strings)

--- a/deptry/dependency_getter/pep_621.py
+++ b/deptry/dependency_getter/pep_621.py
@@ -17,18 +17,16 @@ class PEP621DependencyGetter(DependencyGetter):
 
         return DependenciesExtract(dependencies, [])
 
-    @classmethod
-    def _get_dependencies(cls) -> list[Dependency]:
-        pyproject_data = load_pyproject_toml()
+    def _get_dependencies(self) -> list[Dependency]:
+        pyproject_data = load_pyproject_toml(self.config)
         dependency_strings: list[str] = pyproject_data["project"]["dependencies"]
-        return cls._extract_pep_508_dependencies(dependency_strings)
+        return self._extract_pep_508_dependencies(dependency_strings)
 
-    @classmethod
-    def _get_optional_dependencies(cls) -> dict[str, list[Dependency]]:
-        pyproject_data = load_pyproject_toml()
+    def _get_optional_dependencies(self) -> dict[str, list[Dependency]]:
+        pyproject_data = load_pyproject_toml(self.config)
 
         return {
-            group: cls._extract_pep_508_dependencies(dependencies)
+            group: self._extract_pep_508_dependencies(dependencies)
             for group, dependencies in pyproject_data["project"].get("optional-dependencies", {}).items()
         }
 

--- a/deptry/dependency_getter/poetry.py
+++ b/deptry/dependency_getter/poetry.py
@@ -22,14 +22,12 @@ class PoetryDependencyGetter(DependencyGetter):
 
         return DependenciesExtract(dependencies, dev_dependencies)
 
-    @classmethod
-    def _get_poetry_dependencies(cls) -> list[Dependency]:
-        pyproject_data = load_pyproject_toml()
+    def _get_poetry_dependencies(self) -> list[Dependency]:
+        pyproject_data = load_pyproject_toml(self.config)
         dependencies: dict[str, Any] = pyproject_data["tool"]["poetry"]["dependencies"]
-        return cls._get_dependencies(dependencies)
+        return self._get_dependencies(dependencies)
 
-    @classmethod
-    def _get_poetry_dev_dependencies(cls) -> list[Dependency]:
+    def _get_poetry_dev_dependencies(self) -> list[Dependency]:
         """
         These can be either under;
 
@@ -39,7 +37,7 @@ class PoetryDependencyGetter(DependencyGetter):
         or both.
         """
         dependencies: dict[str, str] = {}
-        pyproject_data = load_pyproject_toml()
+        pyproject_data = load_pyproject_toml(self.config)
 
         with contextlib.suppress(KeyError):
             dependencies = {**pyproject_data["tool"]["poetry"]["dev-dependencies"], **dependencies}
@@ -47,7 +45,7 @@ class PoetryDependencyGetter(DependencyGetter):
         with contextlib.suppress(KeyError):
             dependencies = {**pyproject_data["tool"]["poetry"]["group"]["dev"]["dependencies"], **dependencies}
 
-        return cls._get_dependencies(dependencies)
+        return self._get_dependencies(dependencies)
 
     @classmethod
     def _get_dependencies(cls, poetry_dependencies: dict[str, Any]) -> list[Dependency]:

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 from enum import Enum
+from pathlib import Path
 
 from deptry.utils import load_pyproject_toml
 
@@ -24,7 +25,8 @@ class DependencySpecificationDetector:
 
     """
 
-    def __init__(self, requirements_txt: tuple[str, ...] = ("requirements.txt",)) -> None:
+    def __init__(self, config: Path, requirements_txt: tuple[str, ...] = ("requirements.txt",)) -> None:
+        self.config = config
         self.requirements_txt = requirements_txt
 
     def detect(self) -> DependencyManagementFormat:
@@ -42,18 +44,16 @@ class DependencySpecificationDetector:
             f" file(s) called '{', '.join(self.requirements_txt)}' found. Exiting."
         )
 
-    @staticmethod
-    def _project_contains_pyproject_toml() -> bool:
-        if "pyproject.toml" in os.listdir():
+    def _project_contains_pyproject_toml(self) -> bool:
+        if self.config.exists():
             logging.debug("pyproject.toml found!")
             return True
         else:
             logging.debug("No pyproject.toml found.")
             return False
 
-    @staticmethod
-    def _project_uses_poetry() -> bool:
-        pyproject_toml = load_pyproject_toml()
+    def _project_uses_poetry(self) -> bool:
+        pyproject_toml = load_pyproject_toml(self.config)
         try:
             pyproject_toml["tool"]["poetry"]["dependencies"]
             logging.debug(
@@ -69,9 +69,8 @@ class DependencySpecificationDetector:
             pass
         return False
 
-    @staticmethod
-    def _project_uses_pdm() -> bool:
-        pyproject_toml = load_pyproject_toml()
+    def _project_uses_pdm(self) -> bool:
+        pyproject_toml = load_pyproject_toml(self.config)
         try:
             pyproject_toml["tool"]["pdm"]["dev-dependencies"]
             logging.debug(
@@ -87,9 +86,8 @@ class DependencySpecificationDetector:
             pass
         return False
 
-    @staticmethod
-    def _project_uses_pep_621() -> bool:
-        pyproject_toml = load_pyproject_toml()
+    def _project_uses_pep_621(self) -> bool:
+        pyproject_toml = load_pyproject_toml(self.config)
         try:
             pyproject_toml["project"]
             logging.debug(

--- a/deptry/utils.py
+++ b/deptry/utils.py
@@ -10,12 +10,10 @@ if sys.version_info >= (3, 11):
 else:
     import tomli as tomllib
 
-PYPROJECT_TOML_PATH = "./pyproject.toml"
 
-
-def load_pyproject_toml(pyproject_toml_path: str = PYPROJECT_TOML_PATH) -> dict[str, Any]:
+def load_pyproject_toml(config: Path) -> dict[str, Any]:
     try:
-        with Path(pyproject_toml_path).open("rb") as pyproject_file:
+        with config.open("rb") as pyproject_file:
             return tomllib.load(pyproject_file)
     except FileNotFoundError:
         raise FileNotFoundError(f"No file `pyproject.toml` found in directory {os.getcwd()}") from None

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,6 @@
 _deptry_ can be configured with command line arguments or by adding a `[tool.deptry]` section to `pyproject.toml`. Explanation for the command line arguments can
 be obtained by running `deptry --help`, and examples are given below. For configuration using `pyproject.toml`, see [Configuration with pyproject.toml](./pyproject-toml.md)
 
-
 ## Basic Usage
 
 _deptry_ can be run with
@@ -16,9 +15,11 @@ deptry .
 
 where `.` is the path to the root directory of the project to be scanned. All other arguments should be specified relative to this directory.
 
+If you want to configure _deptry_ using `pyproject.toml`, or if your dependencies are stored in `pyproject.toml`, but it is located in another location than the one _deptry_ is run from, you can specify the location to it by using `--config <path_to_pyproject.toml>` argument.
+
 ## Dependencies extraction
 
-To determine the project's dependencies, _deptry_ will scan the root directory for files in the following order:
+To determine the project's dependencies, _deptry_ will scan the directory it is run from for files in the following order:
 
 - If a `pyproject.toml` file with a `[tool.poetry.dependencies]` section is found, _deptry_ will assume it uses Poetry and extract:
     - dependencies from `[tool.poetry.dependencies]` section

--- a/tests/cli/test_cli_pyproject_different_directory.py
+++ b/tests/cli/test_cli_pyproject_different_directory.py
@@ -1,0 +1,30 @@
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from _pytest.tmpdir import TempPathFactory
+
+from tests.utils import run_within_dir
+
+
+@pytest.fixture(scope="session")
+def pep_621_dir_with_pyproject_different_directory(tmp_path_factory: TempPathFactory) -> Path:
+    tmp_path_proj = tmp_path_factory.getbasetemp() / "project_with_pyproject_different_directory"
+    shutil.copytree("tests/data/project_with_pyproject_different_directory", str(tmp_path_proj))
+    with run_within_dir(tmp_path_proj):
+        assert subprocess.check_call(shlex.split("pip install ."), cwd="a_sub_directory") == 0
+    return tmp_path_proj
+
+
+def test_cli_with_pyproject_different_directory(pep_621_dir_with_pyproject_different_directory: Path) -> None:
+    with run_within_dir(pep_621_dir_with_pyproject_different_directory):
+        result = subprocess.run(
+            shlex.split("deptry --config a_sub_directory/pyproject.toml src"), capture_output=True, text=True
+        )
+        assert result.returncode == 1
+        assert (
+            "The project contains obsolete dependencies:\n\n\tisort\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
+        )
+        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr

--- a/tests/data/project_with_pyproject_different_directory/a_sub_directory/pyproject.toml
+++ b/tests/data/project_with_pyproject_different_directory/a_sub_directory/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
+version = "1.2.3"
+requires-python = ">=3.7"
+dependencies = [
+    "toml",
+    "urllib3>=1.26.12",
+    "isort>=5.10.1",
+    "click>=8.1.3",
+    "requests>=2.28.1",
+    "pkginfo>=1.8.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black==22.10.0",
+    "mypy==0.982",
+]
+test = [
+  "pytest==7.2.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.deptry]
+ignore_obsolete = ["pkginfo"]

--- a/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/bar.py
+++ b/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/bar.py
@@ -1,0 +1,1 @@
+from project_with_src_directory.foo import a_local_method

--- a/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/foo.py
+++ b/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/foo.py
@@ -1,0 +1,11 @@
+from os import chdir, walk
+from pathlib import Path
+
+import black
+import click
+import white as w
+from urllib3 import contrib
+
+
+def a_local_method():
+    ...

--- a/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/notebook.ipynb
+++ b/tests/data/project_with_pyproject_different_directory/src/project_with_src_directory/notebook.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9f4924ec-2200-4801-9d49-d4833651cbc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import click\n",
+    "from urllib3 import contrib\n",
+    "import toml"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/dependency_getter/test_pdm.py
+++ b/tests/dependency_getter/test_pdm.py
@@ -20,7 +20,7 @@ dependencies = [
         with open("pyproject.toml", "w") as f:
             f.write(fake_pyproject_toml)
 
-        dependencies = PDMDependencyGetter().get().dependencies
+        dependencies = PDMDependencyGetter(Path("pyproject.toml")).get().dependencies
 
         assert len(dependencies) == 4
 
@@ -69,7 +69,7 @@ tox = [
         with open("pyproject.toml", "w") as f:
             f.write(fake_pyproject_toml)
 
-        dev_dependencies = PDMDependencyGetter().get().dev_dependencies
+        dev_dependencies = PDMDependencyGetter(Path("pyproject.toml")).get().dev_dependencies
 
         assert len(dev_dependencies) == 3
 

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -29,7 +29,7 @@ group2 = [
         with open("pyproject.toml", "w") as f:
             f.write(fake_pyproject_toml)
 
-        dependencies = PEP621DependencyGetter().get().dependencies
+        dependencies = PEP621DependencyGetter(Path("pyproject.toml")).get().dependencies
 
         assert len(dependencies) == 7
 

--- a/tests/dependency_getter/test_poetry.py
+++ b/tests/dependency_getter/test_poetry.py
@@ -18,7 +18,7 @@ foo =  { version = ">=2.5.1,<4.0.0", optional = true }"""
         with open("pyproject.toml", "w") as f:
             f.write(fake_pyproject_toml)
 
-        dependencies_extract = PoetryDependencyGetter().get()
+        dependencies_extract = PoetryDependencyGetter(Path("pyproject.toml")).get()
         dependencies = dependencies_extract.dependencies
         dev_dependencies = dependencies_extract.dev_dependencies
 

--- a/tests/dependency_getter/test_requirements_txt.py
+++ b/tests/dependency_getter/test_requirements_txt.py
@@ -29,7 +29,7 @@ requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
         with open("requirements.txt", "w") as f:
             f.write(fake_requirements_txt)
 
-        dependencies_extract = RequirementsTxtDependencyGetter().get()
+        dependencies_extract = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get()
         dependencies = dependencies_extract.dependencies
 
         assert len(dependencies) == 17
@@ -62,7 +62,7 @@ git+https://github.com/abc123/bar-foo@xyz789#egg=bar-fooo"""
         with open("requirements.txt", "w") as f:
             f.write(fake_requirements_txt)
 
-        dependencies_extract = RequirementsTxtDependencyGetter().get()
+        dependencies_extract = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get()
         dependencies = dependencies_extract.dependencies
 
         assert len(dependencies) == 5
@@ -80,7 +80,9 @@ def test_single(tmp_path: Path) -> None:
         with open("req.txt", "w") as f:
             f.write("click==8.1.3 #123asd\ncolorama==0.4.5")
 
-        dependencies_extract = RequirementsTxtDependencyGetter(requirements_txt=("req.txt",)).get()
+        dependencies_extract = RequirementsTxtDependencyGetter(
+            Path("pyproject.toml"), requirements_txt=("req.txt",)
+        ).get()
         dependencies = dependencies_extract.dependencies
 
         assert len(dependencies) == 2
@@ -97,7 +99,9 @@ def test_multiple(tmp_path: Path) -> None:
         with open("bar.txt", "w") as f:
             f.write("bar")
 
-        dependencies_extract = RequirementsTxtDependencyGetter(requirements_txt=("foo.txt", "bar.txt")).get()
+        dependencies_extract = RequirementsTxtDependencyGetter(
+            Path("pyproject.toml"), requirements_txt=("foo.txt", "bar.txt")
+        ).get()
         dependencies = dependencies_extract.dependencies
 
         assert len(dependencies) == 2
@@ -114,7 +118,7 @@ def test_dev_single(tmp_path: Path) -> None:
         with open("requirements-dev.txt", "w") as f:
             f.write("click==8.1.3 #123asd\ncolorama==0.4.5")
 
-        dependencies_extract = RequirementsTxtDependencyGetter().get()
+        dependencies_extract = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get()
         dev_dependencies = dependencies_extract.dev_dependencies
 
         assert len(dependencies_extract.dependencies) == 0
@@ -135,7 +139,7 @@ def test_dev_multiple(tmp_path: Path) -> None:
         with open("dev-requirements.txt", "w") as f:
             f.write("bar")
 
-        dependencies_extract = RequirementsTxtDependencyGetter().get()
+        dependencies_extract = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get()
         dev_dependencies = dependencies_extract.dev_dependencies
 
         assert len(dependencies_extract.dependencies) == 0
@@ -154,7 +158,9 @@ def test_dev_multiple_with_arguments(tmp_path: Path) -> None:
         with open("bar.txt", "w") as f:
             f.write("bar")
 
-        dependencies_extract = RequirementsTxtDependencyGetter(requirements_txt_dev=("foo.txt", "bar.txt")).get()
+        dependencies_extract = RequirementsTxtDependencyGetter(
+            Path("pyproject.toml"), requirements_txt_dev=("foo.txt", "bar.txt")
+        ).get()
         dev_dependencies = dependencies_extract.dev_dependencies
 
         assert len(dependencies_extract.dependencies) == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,10 +49,9 @@ def test_read_configuration_from_pyproject_toml_exists(tmp_path: Path) -> None:
         with open("pyproject.toml", "w") as f:
             f.write(pyproject_toml_content)
 
-        assert (
-            read_configuration_from_pyproject_toml(click_context, click.UNPROCESSED(None), "pyproject.toml")
-            == "pyproject.toml"
-        )
+        assert read_configuration_from_pyproject_toml(
+            click_context, click.UNPROCESSED(None), Path("pyproject.toml")
+        ) == Path("pyproject.toml")
 
     assert click_context.default_map == {
         "exclude": ["foo", "bar"],
@@ -73,12 +72,9 @@ def test_read_configuration_from_pyproject_toml_exists(tmp_path: Path) -> None:
 
 def test_read_configuration_from_pyproject_toml_file_not_found(caplog: LogCaptureFixture) -> None:
     with caplog.at_level(logging.DEBUG):
-        assert (
-            read_configuration_from_pyproject_toml(
-                click.Context(click.Command("")), click.UNPROCESSED(None), "a_non_existent_pyproject.toml"
-            )
-            is None
-        )
+        assert read_configuration_from_pyproject_toml(
+            click.Context(click.Command("")), click.UNPROCESSED(None), Path("a_non_existent_pyproject.toml")
+        ) == Path("a_non_existent_pyproject.toml")
 
     assert "No pyproject.toml file to read configuration from." in caplog.text
 
@@ -96,11 +92,8 @@ def test_read_configuration_from_pyproject_toml_file_without_deptry_section(
             f.write(pyproject_toml_content)
 
         with caplog.at_level(logging.DEBUG):
-            assert (
-                read_configuration_from_pyproject_toml(
-                    click.Context(click.Command("")), click.UNPROCESSED(None), "pyproject.toml"
-                )
-                is None
-            )
+            assert read_configuration_from_pyproject_toml(
+                click.Context(click.Command("")), click.UNPROCESSED(None), Path("pyproject.toml")
+            ) == Path("pyproject.toml")
 
     assert "No configuration for deptry was found in pyproject.toml." in caplog.text

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -12,7 +12,7 @@ def test_poetry(tmp_path: Path) -> None:
         with open("pyproject.toml", "w") as f:
             f.write('[tool.poetry.dependencies]\nfake = "10"')
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.POETRY
 
 
@@ -21,7 +21,7 @@ def test_requirements_txt(tmp_path: Path) -> None:
         with open("requirements.txt", "w") as f:
             f.write('foo >= "1.0"')
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.REQUIREMENTS_TXT
 
 
@@ -33,7 +33,7 @@ def test_pdm_with_dev_dependencies(tmp_path: Path) -> None:
                 ' "scm"}\n[tool.pdm.dev-dependencies]\ngroup=["bar"]'
             )
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.PDM
 
 
@@ -42,7 +42,7 @@ def test_pdm_without_dev_dependencies(tmp_path: Path) -> None:
         with open("pyproject.toml", "w") as f:
             f.write('[project]\ndependencies=["foo"]\n[tool.pdm]\nversion = {source = "scm"}')
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.PEP_621
 
 
@@ -51,7 +51,7 @@ def test_pep_621(tmp_path: Path) -> None:
         with open("pyproject.toml", "w") as f:
             f.write('[project]\ndependencies=["foo"]')
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.PEP_621
 
 
@@ -67,7 +67,7 @@ def test_both(tmp_path: Path) -> None:
         with open("requirements.txt", "w") as f:
             f.write('foo >= "1.0"')
 
-        spec = DependencySpecificationDetector().detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml")).detect()
         assert spec == DependencyManagementFormat.POETRY
 
 
@@ -76,7 +76,7 @@ def test_requirements_txt_with_argument(tmp_path: Path) -> None:
         with open("req.txt", "w") as f:
             f.write('foo >= "1.0"')
 
-        spec = DependencySpecificationDetector(requirements_txt=("req.txt",)).detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml"), requirements_txt=("req.txt",)).detect()
         assert spec == DependencyManagementFormat.REQUIREMENTS_TXT
 
 
@@ -86,14 +86,14 @@ def test_requirements_txt_with_argument_not_root_directory(tmp_path: Path) -> No
         with open("req/req.txt", "w") as f:
             f.write('foo >= "1.0"')
 
-        spec = DependencySpecificationDetector(requirements_txt=("req/req.txt",)).detect()
+        spec = DependencySpecificationDetector(Path("pyproject.toml"), requirements_txt=("req/req.txt",)).detect()
         assert spec == DependencyManagementFormat.REQUIREMENTS_TXT
 
 
 def test_raises_filenotfound_error(tmp_path: Path) -> None:
     with run_within_dir(tmp_path):
         with pytest.raises(FileNotFoundError) as e:
-            DependencySpecificationDetector(requirements_txt=("req/req.txt",)).detect()
+            DependencySpecificationDetector(Path("pyproject.toml"), requirements_txt=("req/req.txt",)).detect()
         assert (
             "No file called 'pyproject.toml' with a [tool.poetry.dependencies], [tool.pdm] or [project] section or"
             " file(s)"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+
 from deptry.utils import load_pyproject_toml
 
 
 def test_load_pyproject_toml() -> None:
-    assert load_pyproject_toml("tests/data/example_project/pyproject.toml") == {
+    assert load_pyproject_toml(Path("tests/data/example_project/pyproject.toml")) == {
         "tool": {
             "deptry": {"ignore_obsolete": ["pkginfo"]},
             "poetry": {


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

This PR builds upon https://github.com/fpgmaas/deptry/pull/244, to allow explicitly specifying the location of `pyproject.toml`, which can be useful for projects passing a root directory different than `.` where `pyproject.toml` is stored in the specified root directory.