### PR TITLE
Exclude files from `.gitignore`

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -9,6 +9,8 @@ from deptry.compat import metadata
 from deptry.config import read_configuration_from_pyproject_toml
 from deptry.core import Core
 
+DEFAULT_EXCLUDE = ("venv", r"\.venv", r"\.direnv", "tests", r"\.git", "setup.py")
+
 
 class CommaSeparatedTupleParamType(click.ParamType):
     name = "tuple"
@@ -129,12 +131,11 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     "-e",
     multiple=True,
     type=str,
-    help="""A regular expression for directories or files in which .py files should not be scanned for imports to determine if there are dependency issues.
+    help=f"""A regular expression for directories or files in which .py files should not be scanned for imports to determine if there are dependency issues.
     Can be used multiple times by specifying the argument multiple times. re.match() is used to match the expressions, which by default checks for a match only at the beginning of a string.
     For example: `deptry . -e ".*/foo/" -e bar"` Note that this overwrites the defaults.
+    [default: {", ".join(DEFAULT_EXCLUDE)}
     """,
-    default=("venv", r"\.venv", r"\.direnv", "tests", r"\.git", "setup.py"),
-    show_default=True,
 )
 @click.option(
     "--extend-exclude",
@@ -217,8 +218,9 @@ def deptry(
         ignore_missing=ignore_missing,
         ignore_transitive=ignore_transitive,
         ignore_misplaced_dev=ignore_misplaced_dev,
-        exclude=exclude,
+        exclude=exclude or DEFAULT_EXCLUDE,
         extend_exclude=extend_exclude,
+        using_default_exclude=not exclude,
         ignore_notebooks=ignore_notebooks,
         skip_obsolete=skip_obsolete,
         skip_missing=skip_missing,

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -38,6 +38,7 @@ class Core:
     skip_misplaced_dev: bool
     exclude: tuple[str, ...]
     extend_exclude: tuple[str, ...]
+    using_default_exclude: bool
     ignore_notebooks: bool
     requirements_txt: tuple[str, ...]
     requirements_txt_dev: tuple[str, ...]
@@ -52,7 +53,7 @@ class Core:
         dependencies_extract = self._get_dependencies(dependency_management_format)
 
         all_python_files = PythonFileFinder(
-            self.exclude, self.extend_exclude, self.ignore_notebooks
+            self.exclude, self.extend_exclude, self.using_default_exclude, self.ignore_notebooks
         ).get_all_python_files_in(self.root)
 
         local_modules = self._get_local_modules()

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -52,7 +52,7 @@ class Core:
         dependencies_extract = self._get_dependencies(dependency_management_format)
 
         all_python_files = PythonFileFinder(
-            exclude=self.exclude + self.extend_exclude, ignore_notebooks=self.ignore_notebooks
+            self.exclude, self.extend_exclude, self.ignore_notebooks
         ).get_all_python_files_in(self.root)
 
         local_modules = self._get_local_modules()

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -5,6 +5,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Pattern
 
 
 @dataclass
@@ -31,15 +32,21 @@ class PythonFileFinder:
         for root_str, dirs, files in os.walk(directory, topdown=True):
             root = Path(root_str)
 
-            if self.exclude and ignore_regex.match(str(root)):
+            if self._is_directory_ignored(root, ignore_regex):
                 dirs[:] = []
                 continue
 
             for file_str in files:
                 file = root / file_str
-                if file.suffix in file_lookup_suffixes and (not self.exclude or not ignore_regex.match(str(file))):
+                if not self._is_file_ignored(file, file_lookup_suffixes, ignore_regex):
                     source_files.append(file)
 
         logging.debug("Python files to scan for imports:\n%s\n", "\n".join([str(file) for file in source_files]))
 
         return source_files
+
+    def _is_directory_ignored(self, directory: Path, ignore_regex: Pattern[str]) -> bool:
+        return bool(self.exclude and ignore_regex.match(str(directory)))
+
+    def _is_file_ignored(self, file: Path, file_lookup_suffixes: set[str], ignore_regex: Pattern[str]) -> bool:
+        return bool(file.suffix not in file_lookup_suffixes or (self.exclude and ignore_regex.match(str(file))))

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Pattern
 
+from pathspec import PathSpec
+
 
 @dataclass
 class PythonFileFinder:
@@ -32,6 +34,8 @@ class PythonFileFinder:
         ignore_regex = re.compile("|".join(self.exclude + self.extend_exclude))
         file_lookup_suffixes = {".py"} if self.ignore_notebooks else {".py", ".ipynb"}
 
+        gitignore_spec = self._generate_gitignore_pathspec(directory)
+
         for root_str, dirs, files in os.walk(directory, topdown=True):
             root = Path(root_str)
 
@@ -41,7 +45,7 @@ class PythonFileFinder:
 
             for file_str in files:
                 file = root / file_str
-                if not self._is_file_ignored(file, file_lookup_suffixes, ignore_regex):
+                if not self._is_file_ignored(file, file_lookup_suffixes, ignore_regex, gitignore_spec):
                     source_files.append(file)
 
         logging.debug("Python files to scan for imports:\n%s\n", "\n".join([str(file) for file in source_files]))
@@ -51,8 +55,22 @@ class PythonFileFinder:
     def _is_directory_ignored(self, directory: Path, ignore_regex: Pattern[str]) -> bool:
         return bool((self.exclude + self.extend_exclude) and ignore_regex.match(str(directory)))
 
-    def _is_file_ignored(self, file: Path, file_lookup_suffixes: set[str], ignore_regex: Pattern[str]) -> bool:
+    def _is_file_ignored(
+        self, file: Path, file_lookup_suffixes: set[str], ignore_regex: Pattern[str], gitignore_spec: PathSpec | None
+    ) -> bool:
         return bool(
             file.suffix not in file_lookup_suffixes
             or ((self.exclude + self.extend_exclude) and ignore_regex.match(str(file)))
+            or (gitignore_spec and gitignore_spec.match_file(file))
         )
+
+    def _generate_gitignore_pathspec(self, directory: Path) -> PathSpec | None:
+        # If `exclude` is explicitly set, `.gitignore` is not taken into account.
+        if not self.using_default_exclude:
+            return None
+
+        try:
+            with (directory / ".gitignore").open() as gitignore:
+                return PathSpec.from_lines("gitwildmatch", gitignore)
+        except FileNotFoundError:
+            return None

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -15,11 +15,13 @@ class PythonFileFinder:
     Args:
         exclude: A list of regex patterns of paths to ignore.
         extend_exclude: An additional list of regex patterns of paths to ignore.
+        using_default_exclude: Whether the exclude list was explicitly set, or the default was used.
         ignore_notebooks: If ignore_notebooks is set to True, .ipynb files are ignored and only .py files are returned.
     """
 
     exclude: tuple[str, ...]
     extend_exclude: tuple[str, ...]
+    using_default_exclude: bool
     ignore_notebooks: bool = False
 
     def get_all_python_files_in(self, directory: Path) -> list[Path]:

--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import logging
 import os
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 
+@dataclass
 class PythonFileFinder:
     """
     Get a list of all .py and .ipynb files recursively within a directory.
@@ -15,9 +17,8 @@ class PythonFileFinder:
         ignore_notebooks: If ignore_notebooks is set to True, .ipynb files are ignored and only .py files are returned.
     """
 
-    def __init__(self, exclude: tuple[str, ...], ignore_notebooks: bool = False) -> None:
-        self.exclude = exclude
-        self.ignore_notebooks = ignore_notebooks
+    exclude: tuple[str, ...]
+    ignore_notebooks: bool = False
 
     def get_all_python_files_in(self, directory: Path) -> list[Path]:
         logging.debug("Collecting Python files to scan...")

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,8 +38,11 @@ _deptry_ can also be configured to look for `requirements.txt` files with other 
 ## Excluding files and directories
 
 To determine issues with imported modules and dependencies, _deptry_ will scan the working directory and its subdirectories recursively for `.py` and `.ipynb` files, so it can
-extract the imported modules from those files. Any files solely used for development purposes, such as files used for unit testing, should not be scanned. By default, the directories
+extract the imported modules from those files. Any file solely used for development purposes, such as a file used for unit testing, should not be scanned. By default, the directories
 `venv`, `.venv`, `.direnv`, `tests`, `.git` and the file `setup.py` are excluded.
+
+By default, _deptry_ also reads entries in `.gitignore` file, to ignore any pattern present in the file, similarly to
+what `git` does.
 
 To ignore other directories and files than the defaults, use the `--exclude` (or `-e`) flag. The argument can either be one long regular expression, or it can be reused multiple times to pass multiple smaller regular expressions. The paths should be specified as paths relative to the directory _deptry_ is running in, without the trailing `./`. An example:
 
@@ -50,15 +53,18 @@ deptry . --exclude "bar|.*/foo/"
 
 The two statements above are equivalent, and will both ignore all files in the directory `bar`, and all files within any directory named `foo`.
 
-Note that using the `--exclude` argument overwrites the defaults. To add additional patterns to ignore
-on top of the defaults instead of overwriting them, use the `--extend-exclude` (or `-ee`) flag.
+Note that using the `--exclude` argument overwrites the defaults, and will prevent _deptry_ from considering entries in
+`.gitignore`.
+To add additional patterns to ignore on top of the defaults instead of overwriting them, or to make sure that _deptry_
+still considers `.gitignore`, use the `--extend-exclude` (or `-ee`) flag.
 
 ```sh
 deptry . -ee bar -ee ".*/foo/"
 deptry . --extend-exclude "bar|.*/foo/"
 ```
 
-This will exclude `venv`, `.venv`, `.direnv`, `.git`, `tests`, `setup.py`, `bar`, and any directory named `foo`.
+This will exclude `venv`, `.venv`, `.direnv`, `.git`, `tests`, `setup.py`, `bar`, and any directory named `foo`, as well
+as entries in `.gitignore`, if there are some.
 
 ## Increased verbosity
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -580,6 +580,18 @@ files = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.10.3"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pathspec-0.10.3-py3-none-any.whl", hash = "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6"},
+    {file = "pathspec-0.10.3.tar.gz", hash = "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"},
+]
+
+[[package]]
 name = "platformdirs"
 version = "2.6.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -1021,4 +1033,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "132f4017005caa5976669f8af03192c01f651224aafa6df654449e0a9dc5097c"
+content-hash = "bcf196ecd7d11e9ddf6abc2e25660f491c3e6e1f471f4d736830a952340a57b6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,7 @@ module = [
 warn_unused_ignores = false
 
 [tool.deptry]
-exclude = [
-    "venv",
-    ".venv",
+extend_exclude = [
     "docs",
     "tests",
     "scripts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,11 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
-tomli = { version = "^2.0.1", python = "<3.11" }
+chardet = ">=4.0.0"
 click = "^8.0.0"
 importlib-metadata = { version = "*", python = "<=3.7" }
-chardet = ">=4.0.0"
+pathspec = ">=0.9.0"
+tomli = { version = "^2.0.1", python = "<3.11" }
 
 [tool.poetry.group.dev.dependencies]
 mypy = "^0.991"

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -23,7 +23,6 @@ def test_cli_returns_error(dir_with_venv_installed: Path) -> None:
     with run_within_dir(dir_with_venv_installed):
         result = subprocess.run(shlex.split("poetry run deptry ."), capture_output=True, text=True)
         assert result.returncode == 1
-        print(result.stderr)
         assert "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\n" in result.stderr
         assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
         assert "There are imported modules from development dependencies detected:\n\n\tblack\n\n" in result.stderr

--- a/tests/cli/test_cli_gitignore.py
+++ b/tests/cli/test_cli_gitignore.py
@@ -1,0 +1,32 @@
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from _pytest.tmpdir import TempPathFactory
+
+from tests.utils import run_within_dir
+
+
+@pytest.fixture(scope="session")
+def dir_with_gitignore(tmp_path_factory: TempPathFactory) -> Path:
+    tmp_path_proj = tmp_path_factory.getbasetemp() / "project_with_gitignore"
+    shutil.copytree("tests/data/project_with_gitignore", str(tmp_path_proj))
+    with run_within_dir(tmp_path_proj):
+        assert subprocess.check_call(shlex.split("pip install .")) == 0
+    return tmp_path_proj
+
+
+def test_cli_gitignore_is_used(dir_with_gitignore: Path) -> None:
+    with run_within_dir(dir_with_gitignore):
+        result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "The project contains obsolete dependencies:\n\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
+
+
+def test_cli_gitignore_is_not_used(dir_with_gitignore: Path) -> None:
+    with run_within_dir(dir_with_gitignore):
+        result = subprocess.run(shlex.split("deptry . --exclude build/|src/bar.py"), capture_output=True, text=True)
+        assert result.returncode == 1
+        assert "The project contains obsolete dependencies:\n\n\tisort\n\tpytest\n\trequests\n\n" in result.stderr

--- a/tests/cli/test_cli_pdm.py
+++ b/tests/cli/test_cli_pdm.py
@@ -22,7 +22,6 @@ def test_cli_with_pdm(pdm_dir_with_venv_installed: Path) -> None:
     with run_within_dir(pdm_dir_with_venv_installed):
         result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
         assert result.returncode == 1
-        print(result.stderr)
         assert "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\n" in result.stderr
         assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
         assert "There are imported modules from development dependencies detected:\n\n\tblack\n\n" in result.stderr

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -22,7 +22,6 @@ def test_cli_with_pep_621(pep_621_dir_with_venv_installed: Path) -> None:
     with run_within_dir(pep_621_dir_with_venv_installed):
         result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
         assert result.returncode == 1
-        print(result.stderr)
         assert (
             "The project contains obsolete dependencies:\n\n\tisort\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
         )

--- a/tests/data/project_with_gitignore/.gitignore
+++ b/tests/data/project_with_gitignore/.gitignore
@@ -1,0 +1,1 @@
+foobar.py

--- a/tests/data/project_with_gitignore/pyproject.toml
+++ b/tests/data/project_with_gitignore/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
+version = "1.2.3"
+requires-python = ">=3.7"
+dependencies = [
+    "toml",
+    "urllib3>=1.26.12",
+    "isort>=5.10.1",
+    "click>=8.1.3",
+    "requests>=2.28.1",
+    "pkginfo>=1.8.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black==22.10.0",
+    "mypy==0.982",
+]
+test = [
+  "pytest==7.2.0",
+]
+
+[build-system]
+requires = ["setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.deptry]
+ignore_obsolete = ["pkginfo"]

--- a/tests/data/project_with_gitignore/src/bar.py
+++ b/tests/data/project_with_gitignore/src/bar.py
@@ -1,0 +1,1 @@
+import isort

--- a/tests/data/project_with_gitignore/src/foo.py
+++ b/tests/data/project_with_gitignore/src/foo.py
@@ -1,0 +1,2 @@
+import black
+import click

--- a/tests/data/project_with_gitignore/src/foobar.py
+++ b/tests/data/project_with_gitignore/src/foobar.py
@@ -1,0 +1,1 @@
+import mypy

--- a/tests/data/project_with_gitignore/src/notebook.ipynb
+++ b/tests/data/project_with_gitignore/src/notebook.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9f4924ec-2200-4801-9d49-d4833651cbc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import click\n",
+    "from urllib3 import contrib\n",
+    "import toml"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_python_file_finder.py
+++ b/tests/test_python_file_finder.py
@@ -29,7 +29,9 @@ def test_simple(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=(".venv",), extend_exclude=("other_dir",)).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(
+            exclude=(".venv",), extend_exclude=("other_dir",), using_default_exclude=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
@@ -48,7 +50,9 @@ def test_only_matches_start(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=("subdir",), extend_exclude=()).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(
+            exclude=("subdir",), extend_exclude=(), using_default_exclude=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
@@ -60,14 +64,14 @@ def test_matches_ipynb(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=(), extend_exclude=(), ignore_notebooks=False).get_all_python_files_in(
-            Path(".")
-        )
+        files = PythonFileFinder(
+            exclude=(), extend_exclude=(), using_default_exclude=False, ignore_notebooks=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 1
         assert "dir/subdir/file1.ipynb" in [str(file) for file in files]
-        files = PythonFileFinder(exclude=(), extend_exclude=(), ignore_notebooks=True).get_all_python_files_in(
-            Path(".")
-        )
+        files = PythonFileFinder(
+            exclude=(), extend_exclude=(), using_default_exclude=False, ignore_notebooks=True
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 0
 
 
@@ -85,13 +89,13 @@ def test_regex_argument(tmp_path: Path) -> None:
         create_files_from_list_of_dicts(paths)
 
         files = PythonFileFinder(
-            exclude=(".*file1",), extend_exclude=(), ignore_notebooks=False
+            exclude=(".*file1",), extend_exclude=(), using_default_exclude=False, ignore_notebooks=False
         ).get_all_python_files_in(Path("."))
         assert len(files) == 4
         assert not any(["file1" in str(file) for file in files])
 
         files = PythonFileFinder(
-            exclude=(".cache|other.*subdir",), extend_exclude=(), ignore_notebooks=False
+            exclude=(".cache|other.*subdir",), extend_exclude=(), using_default_exclude=False, ignore_notebooks=False
         ).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert not any(["other_dir" in str(file) for file in files])
@@ -99,7 +103,7 @@ def test_regex_argument(tmp_path: Path) -> None:
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
         files = PythonFileFinder(
-            exclude=(".*/subdir/",), extend_exclude=(), ignore_notebooks=False
+            exclude=(".*/subdir/",), extend_exclude=(), using_default_exclude=False, ignore_notebooks=False
         ).get_all_python_files_in(Path("."))
         assert len(files) == 2
         assert not any(["subdir" in str(file) for file in files])

--- a/tests/test_python_file_finder.py
+++ b/tests/test_python_file_finder.py
@@ -29,7 +29,7 @@ def test_simple(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=(".venv", "other_dir")).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(exclude=(".venv",), extend_exclude=("other_dir",)).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
@@ -48,7 +48,7 @@ def test_only_matches_start(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=("subdir",)).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(exclude=("subdir",), extend_exclude=()).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
@@ -60,10 +60,14 @@ def test_matches_ipynb(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=(), ignore_notebooks=False).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(exclude=(), extend_exclude=(), ignore_notebooks=False).get_all_python_files_in(
+            Path(".")
+        )
         assert len(files) == 1
         assert "dir/subdir/file1.ipynb" in [str(file) for file in files]
-        files = PythonFileFinder(exclude=(), ignore_notebooks=True).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(exclude=(), extend_exclude=(), ignore_notebooks=True).get_all_python_files_in(
+            Path(".")
+        )
         assert len(files) == 0
 
 
@@ -80,19 +84,23 @@ def test_regex_argument(tmp_path: Path) -> None:
         ]
         create_files_from_list_of_dicts(paths)
 
-        files = PythonFileFinder(exclude=(".*file1",), ignore_notebooks=False).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(
+            exclude=(".*file1",), extend_exclude=(), ignore_notebooks=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 4
         assert not any(["file1" in str(file) for file in files])
 
-        files = PythonFileFinder(exclude=(".cache|other.*subdir",), ignore_notebooks=False).get_all_python_files_in(
-            Path(".")
-        )
+        files = PythonFileFinder(
+            exclude=(".cache|other.*subdir",), extend_exclude=(), ignore_notebooks=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 3
         assert not any(["other_dir" in str(file) for file in files])
         assert not any([".cache" in str(file) for file in files])
         assert "dir/subdir/file2.py" in [str(file) for file in files]
 
-        files = PythonFileFinder(exclude=(".*/subdir/",), ignore_notebooks=False).get_all_python_files_in(Path("."))
+        files = PythonFileFinder(
+            exclude=(".*/subdir/",), extend_exclude=(), ignore_notebooks=False
+        ).get_all_python_files_in(Path("."))
         assert len(files) == 2
         assert not any(["subdir" in str(file) for file in files])
         assert ".cache/file2.py" in [str(file) for file in files]

--- a/tests/test_python_file_finder.py
+++ b/tests/test_python_file_finder.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pathspec import PathSpec
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
+
 from deptry.python_file_finder import PythonFileFinder
 from tests.utils import run_within_dir
 
@@ -108,3 +111,36 @@ def test_regex_argument(tmp_path: Path) -> None:
         assert len(files) == 2
         assert not any(["subdir" in str(file) for file in files])
         assert ".cache/file2.py" in [str(file) for file in files]
+
+
+def test__generate_gitignore_pathspec_with_non_default_exclude(tmp_path: Path) -> None:
+    gitignore_pathspec = PythonFileFinder(
+        exclude=(), extend_exclude=(), using_default_exclude=False
+    )._generate_gitignore_pathspec(Path("."))
+
+    assert gitignore_pathspec is None
+
+
+def test__generate_gitignore_pathspec_with_non_existing_gitignore(tmp_path: Path) -> None:
+    with run_within_dir(tmp_path):
+        gitignore_pathspec = PythonFileFinder(
+            exclude=(), extend_exclude=(), using_default_exclude=True
+        )._generate_gitignore_pathspec(Path("."))
+
+        assert gitignore_pathspec is None
+
+
+def test__generate_gitignore_pathspec_with_existing_gitignore(tmp_path: Path) -> None:
+    with run_within_dir(tmp_path):
+        with open(Path(".gitignore"), "w") as gitignore:
+            gitignore.write("foo.py\nbar/")
+
+        gitignore_pathspec = PythonFileFinder(
+            exclude=(), extend_exclude=(), using_default_exclude=True
+        )._generate_gitignore_pathspec(Path("."))
+
+        assert isinstance(gitignore_pathspec, PathSpec)
+        assert gitignore_pathspec.patterns == [
+            GitWildMatchPattern("foo.py"),
+            GitWildMatchPattern("bar/"),
+        ]


### PR DESCRIPTION
Resolves #200.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

This PR implements the changes suggested in the linked issue with the help of [pathspec](https://pypi.org/project/pathspec/), with a slight modification: it doesn't empty the default `exclude` list. Since not all projects use `git`, I figured that it might be better to keep this default list.