### PR TITLE
test(cli): use JSON output to simplify tests on errors

### DIFF
--- a/tests/cli/test_cli_pdm.py
+++ b/tests/cli/test_cli_pdm.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
-from tests.utils import run_within_dir
+from tests.utils import get_issues_report, run_within_dir
 
 
 @pytest.fixture(scope="session")
@@ -20,8 +20,12 @@ def pdm_dir_with_venv_installed(tmp_path_factory: TempPathFactory) -> Path:
 
 def test_cli_with_pdm(pdm_dir_with_venv_installed: Path) -> None:
     with run_within_dir(pdm_dir_with_venv_installed):
-        result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
+        result = subprocess.run(shlex.split("deptry . -o report.json"), capture_output=True, text=True)
+
         assert result.returncode == 1
-        assert "The project contains obsolete dependencies:\n\n\tisort\n\trequests\n\n" in result.stderr
-        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
-        assert "There are imported modules from development dependencies detected:\n\n\tblack\n\n" in result.stderr
+        assert get_issues_report() == {
+            "misplaced_dev": ["black"],
+            "missing": ["white"],
+            "obsolete": ["isort", "requests"],
+            "transitive": [],
+        }

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
-from tests.utils import run_within_dir
+from tests.utils import get_issues_report, run_within_dir
 
 
 @pytest.fixture(scope="session")
@@ -20,9 +20,12 @@ def pep_621_dir_with_venv_installed(tmp_path_factory: TempPathFactory) -> Path:
 
 def test_cli_with_pep_621(pep_621_dir_with_venv_installed: Path) -> None:
     with run_within_dir(pep_621_dir_with_venv_installed):
-        result = subprocess.run(shlex.split("deptry ."), capture_output=True, text=True)
+        result = subprocess.run(shlex.split("deptry . -o report.json"), capture_output=True, text=True)
+
         assert result.returncode == 1
-        assert (
-            "The project contains obsolete dependencies:\n\n\tisort\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
-        )
-        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
+        assert get_issues_report() == {
+            "misplaced_dev": [],
+            "missing": ["white"],
+            "obsolete": ["isort", "requests", "mypy", "pytest"],
+            "transitive": [],
+        }

--- a/tests/cli/test_cli_src_directory.py
+++ b/tests/cli/test_cli_src_directory.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from _pytest.tmpdir import TempPathFactory
 
-from tests.utils import run_within_dir
+from tests.utils import get_issues_report, run_within_dir
 
 
 @pytest.fixture(scope="session")
@@ -20,9 +20,12 @@ def pep_621_dir_with_src_directory(tmp_path_factory: TempPathFactory) -> Path:
 
 def test_cli_with_src_directory(pep_621_dir_with_src_directory: Path) -> None:
     with run_within_dir(pep_621_dir_with_src_directory):
-        result = subprocess.run(shlex.split("deptry src"), capture_output=True, text=True)
+        result = subprocess.run(shlex.split("deptry src -o report.json"), capture_output=True, text=True)
+
         assert result.returncode == 1
-        assert (
-            "The project contains obsolete dependencies:\n\n\tisort\n\tmypy\n\tpytest\n\trequests\n\n" in result.stderr
-        )
-        assert "There are dependencies missing from the project's list of dependencies:\n\n\twhite\n\n" in result.stderr
+        assert get_issues_report() == {
+            "misplaced_dev": [],
+            "missing": ["white"],
+            "obsolete": ["isort", "requests", "mypy", "pytest"],
+            "transitive": [],
+        }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
+import json
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator
+from typing import Any, Generator
 
 
 @contextmanager
@@ -23,3 +26,10 @@ def run_within_dir(path: Path) -> Generator[None, None, None]:
         yield
     finally:
         os.chdir(oldpwd)
+
+
+def get_issues_report(path: str = "report.json") -> dict[str, Any]:
+    with open(path) as file:
+        report: dict[str, Any] = json.load(file)
+
+    return report


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

It is rather painful to write CLI tests against the console output in case of errors.

This PR updates CLI tests that check for errors so that they use JSON output, making the assertions way more bearable, while ensuring that all 4 types of issues are checked.