### PR TITLE
feat(extract): don't filter out `setuptools`

### DIFF
--- a/deptry/imports/extract.py
+++ b/deptry/imports/extract.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 
 from deptry.imports.extractors import NotebookImportExtractor, PythonImportExtractor
+from deptry.imports.extractors.base import ImportExtractor
 
 # setuptools is usually available by default, so often not specified in dependencies.
 _FILTERED_OUT_MODULES = {"setuptools"}
@@ -24,14 +25,17 @@ def get_imported_modules_for_list_of_files(list_of_files: list[Path]) -> list[st
 def get_imported_modules_from_file(path_to_file: Path) -> set[str]:
     logging.debug(f"Scanning {path_to_file}...")
 
-    if path_to_file.suffix == ".ipynb":
-        modules = NotebookImportExtractor(path_to_file).extract_imports()
-    else:
-        modules = PythonImportExtractor(path_to_file).extract_imports()
+    modules = _get_extractor_class(path_to_file)(path_to_file).extract_imports()
 
     logging.debug(f"Found the following imports in {str(path_to_file)}: {modules}")
 
     return modules
+
+
+def _get_extractor_class(path_to_file: Path) -> type[ImportExtractor]:
+    if path_to_file.suffix == ".ipynb":
+        return NotebookImportExtractor
+    return PythonImportExtractor
 
 
 def _filter_out_modules(modules: set[str]) -> set[str]:

--- a/deptry/imports/extract.py
+++ b/deptry/imports/extract.py
@@ -7,19 +7,15 @@ from pathlib import Path
 from deptry.imports.extractors import NotebookImportExtractor, PythonImportExtractor
 from deptry.imports.extractors.base import ImportExtractor
 
-# setuptools is usually available by default, so often not specified in dependencies.
-_FILTERED_OUT_MODULES = {"setuptools"}
-
 
 def get_imported_modules_for_list_of_files(list_of_files: list[Path]) -> list[str]:
     logging.info(f"Scanning {len(list_of_files)} files...")
 
-    unique_modules = set(itertools.chain.from_iterable(get_imported_modules_from_file(file) for file in list_of_files))
-    filtered_modules = sorted(_filter_out_modules(unique_modules))
+    modules = sorted(set(itertools.chain.from_iterable(get_imported_modules_from_file(file) for file in list_of_files)))
 
-    logging.debug(f"All imported modules: {filtered_modules}\n")
+    logging.debug(f"All imported modules: {modules}\n")
 
-    return filtered_modules
+    return modules
 
 
 def get_imported_modules_from_file(path_to_file: Path) -> set[str]:
@@ -36,11 +32,3 @@ def _get_extractor_class(path_to_file: Path) -> type[ImportExtractor]:
     if path_to_file.suffix == ".ipynb":
         return NotebookImportExtractor
     return PythonImportExtractor
-
-
-def _filter_out_modules(modules: set[str]) -> set[str]:
-    for filtered_out_module in _FILTERED_OUT_MODULES:
-        if filtered_out_module in modules:
-            logging.debug(f"Found module {filtered_out_module} to be imported, omitting from the list of modules.")
-
-    return modules - _FILTERED_OUT_MODULES

--- a/tests/imports/test_extract.py
+++ b/tests/imports/test_extract.py
@@ -8,7 +8,7 @@ from unittest import mock
 import pytest
 from _pytest.logging import LogCaptureFixture
 
-from deptry.imports.extract import get_imported_modules_for_list_of_files, get_imported_modules_from_file
+from deptry.imports.extract import get_imported_modules_from_file
 from tests.utils import run_within_dir
 
 
@@ -37,16 +37,6 @@ def test_import_parser_ipynb() -> None:
     imported_modules = get_imported_modules_from_file(Path("tests/data/example_project/src/notebook.ipynb"))
 
     assert imported_modules == {"click", "urllib3", "toml"}
-
-
-def test_import_parser_ignores_setuptools(tmp_path: Path) -> None:
-    with run_within_dir(tmp_path):
-        with open("file.py", "w") as f:
-            f.write("import setuptools\nimport foo")
-
-        imported_modules = get_imported_modules_for_list_of_files([Path("file.py")])
-
-        assert imported_modules == ["foo"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #261.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Don't filter out `setuptools` in the import extractor, in order to let users do it explicitly through `ignore_*` settings if really needed.