### PR TITLE
chore(renovate): tweak schedule

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -17,12 +17,12 @@
   labels: ["dependencies"],
 
   // https://docs.renovatebot.com/configuration-options/#schedule
-  schedule: ["on saturday"],
+  schedule: ["before 3am on saturday"],
 
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {
     enabled: true,
-    schedule: ["on saturday"],
+    schedule: ["before 5am on saturday"],
   },
 
   // https://docs.renovatebot.com/configuration-options/#regexmanagers


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

If we don't specify a timeframe, Renovate could create multiple PRs during the day once we merge the first PRs it creates, which can be noisy.

According to
https://docs.renovatebot.com/configuration-options/#schedule, it doesn't support exact time (probably because Renovate runs are not exactly predictable), so setting "before 3am" and "before 5am" should give it enough time to make PRs, while making it almost sure that we won't get new PRs during the day after the first ones created are merged.