### PR TITLE
chore: drop `flake8` to only use `ruff`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: black
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.213"
+    rev: "v0.0.215"
     hooks:
       - id: ruff
         # Respect `exclude` and `extend-exclude` settings.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,6 @@ repos:
         # Respect `exclude` and `extend-exclude` settings.
         args: ["--force-exclude"]
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: "6.0.0"
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - "flake8-bugbear==22.12.6" # renovate: pep440-python-dependency
-          - "flake8-comprehensions==3.10.1" # renovate: pep440-python-dependency
-          - "flake8-simplify==0.19.3" # renovate: pep440-python-dependency
-
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.9.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,17 +15,17 @@ repos:
       - id: pyupgrade
         args: ["--py37-plus"]
 
-  - repo: https://github.com/psf/black
-    rev: "22.12.0"
-    hooks:
-      - id: black
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.215"
     hooks:
       - id: ruff
         # Respect `exclude` and `extend-exclude` settings.
         args: ["--force-exclude"]
+
+  - repo: https://github.com/psf/black
+    rev: "22.12.0"
+    hooks:
+      - id: black
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: "v1.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ select = [
     "F",
     # mccabe
     "C90",
+    # flake8-builtins
+    "A",
     # flake8-comprehensions
     "C4",
     # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,8 @@ select = [
     "I",
     # flake8-bugbear
     "B",
+    # flake8-simplify
+    "SIM",
     # ruff
     "RUF",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,23 +1,3 @@
-[flake8]
-per-file-ignores = __init__.py:F401
-# PEP-8 The following are ignored:
-# E731 do not assign a lambda expression, use a def
-# E203 whitespace before ':'
-# E501 line too long
-# W503 line break before binary operator
-# W605 invalid escape sequence
-ignore = E731, E203, E501, W503, W605
-extend-exclude =
-    docs/source/conf.py,
-    old/*,
-    build/*,
-    dist/*,
-    .venv/*,
-    tests/data/*,
-    venv/*
-max-complexity = 10
-max-line-length = 120
-
 [tox]
 skipsdist = true
 envlist = py37, py38, py39, py310, py311


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

`ruff` now supports most `flake8-simplify` rules (https://github.com/charliermarsh/ruff/issues/998). Since the last ones will most likely be implemented sooner than later, and all other rules we use for `flake8` are implemented, it might be time to fully rely on `ruff` and drop `flake8`.

Also taking the occasion to add [flake8-builtins](https://github.com/charliermarsh/ruff#flake8-builtins-a) rules.