### PR TITLE
chore(renovate): use GitHub Actions regex

### DIFF
--- a/.github/workflows/validate-renovate-config.yml
+++ b/.github/workflows/validate-renovate-config.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches: [main]
 
+env:
+  # renovate: datasource=node depName=node versioning=node
+  NODE_VERSION: "18"
+
 jobs:
   validate-renovate-config:
     runs-on: ubuntu-22.04
@@ -13,5 +17,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18" # renovate: datasource=node depName=node versioning=node
+          node-version: ${{ env.NODE_VERSION }}
       - run: npx -p renovate renovate-config-validator

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,6 +11,8 @@
     ":prHourlyLimitNone",
     // https://docs.renovatebot.com/presets-default/#rebasestaleprs
     ":rebaseStalePrs",
+    // https://docs.renovatebot.com/presets-regexManagers/#regexmanagersgithubactionsversions
+    "regexManagers:githubActionsVersions",
   ],
 
   // https://docs.renovatebot.com/configuration-options/#labels


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Add the recently released https://docs.renovatebot.com/presets-regexManagers/#regexmanagersgithubactionsversions regex and use it for bumping the version of `node`. Current regex doesn't work. I thought it was implemented in this repository, but it was only in my own [Renovate configuration repository](https://github.com/mkniewallner/renovate-config/blob/13ef46c725c5f3872d31ec533cdc86d3c96ed6c2/default.json5#L41-L48) :see_no_evil: 