### PR TITLE
chore: use more `ruff` rules and replace `pyupgrade` and `pygrep-hooks` usages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,6 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: "v3.3.1"
-    hooks:
-      - id: pyupgrade
-        args: ["--py37-plus"]
-
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: "v0.0.230"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,8 +18,3 @@ repos:
     rev: "22.12.0"
     hooks:
       - id: black
-
-  - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: "v1.10.0"
-    hooks:
-      - id: python-check-blanket-noqa

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: ["--py37-plus"]
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.228"
+    rev: "v0.0.230"
     hooks:
       - id: ruff
         # Respect `exclude` and `extend-exclude` settings.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,8 +19,6 @@ repos:
     rev: "v0.0.230"
     hooks:
       - id: ruff
-        # Respect `exclude` and `extend-exclude` settings.
-        args: ["--force-exclude"]
 
   - repo: https://github.com/psf/black
     rev: "22.12.0"

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -46,13 +46,14 @@ class Dependency:
     def find_metadata(self, name: str) -> bool:
         try:
             metadata.distribution(name)  # type: ignore[no-untyped-call]
-            return True
         except PackageNotFoundError:
             logging.warning(
                 f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its"
                 f" corresponding module name is '{name.replace('-','_').lower()}'."
             )
             return False
+        else:
+            return True
 
     def _string_for_printing(self) -> str:
         """

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -60,14 +60,14 @@ class DependencySpecificationDetector:
                 "pyproject.toml contains a [tool.poetry.dependencies] section, so Poetry is used to specify the"
                 " project's dependencies."
             )
-            return True
         except KeyError:
             logging.debug(
                 "pyproject.toml does not contain a [tool.poetry.dependencies] section, so PDM is not used to specify"
                 " the project's dependencies."
             )
-            pass
-        return False
+            return False
+        else:
+            return True
 
     def _project_uses_pdm(self) -> bool:
         pyproject_toml = load_pyproject_toml(self.config)
@@ -77,14 +77,14 @@ class DependencySpecificationDetector:
                 "pyproject.toml contains a [tool.pdm.dev-dependencies] section, so PDM is used to specify the project's"
                 " dependencies."
             )
-            return True
         except KeyError:
             logging.debug(
                 "pyproject.toml does not contain a [tool.pdm.dev-dependencies] section, so PDM is not used to specify"
                 " the project's dependencies."
             )
-            pass
-        return False
+            return False
+        else:
+            return True
 
     def _project_uses_pep_621(self) -> bool:
         pyproject_toml = load_pyproject_toml(self.config)
@@ -93,14 +93,14 @@ class DependencySpecificationDetector:
             logging.debug(
                 "pyproject.toml contains a [project] section, so PEP 621 is used to specify the project's dependencies."
             )
-            return True
         except KeyError:
             logging.debug(
                 "pyproject.toml does not contain a [project] section, so PEP 621 is not used to specify the project's"
                 " dependencies."
             )
-            pass
-        return False
+            return False
+        else:
+            return True
 
     def _project_uses_requirements_txt(self) -> bool:
         check = any(os.path.isfile(requirements_txt) for requirements_txt in self.requirements_txt)

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -88,9 +88,10 @@ class ModuleBuilder:
         """
         try:
             name: str = metadata.metadata(self.name)["Name"]  # type: ignore[no-untyped-call]
-            return name
         except PackageNotFoundError:
             return None
+        else:
+            return name
 
     def _get_corresponding_top_levels_from(self, dependencies: list[Dependency]) -> list[str]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,16 @@ select = [
     "C4",
     # isort
     "I",
+    # flake8-2020
+    "YTT",
+    # flake8-bandit
+    "S",
     # flake8-bugbear
     "B",
+    # flake8-debugger
+    "T10",
+    # flake8-print
+    "T20",
     # flake8-simplify
     "SIM",
     # pygrep-hooks
@@ -118,6 +126,8 @@ select = [
     "UP",
     # ruff
     "RUF",
+    # tryceratops
+    "TRY",
 ]
 ignore = [
     # LineTooLong
@@ -126,3 +136,6 @@ ignore = [
     "E731",
 ]
 extend-exclude = ["tests/data/*"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ select = [
     "B",
     # flake8-simplify
     "SIM",
+    # pyupgrade
+    "UP",
     # ruff
     "RUF",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,30 +96,30 @@ target-version = "py37"
 line-length = 120
 fix = true
 select = [
-    # pycodestyle
-    "E", "W",
-    # pyflakes
-    "F",
-    # mccabe
-    "C90",
-    # flake8-builtins
-    "A",
-    # flake8-comprehensions
-    "C4",
-    # isort
-    "I",
     # flake8-2020
     "YTT",
     # flake8-bandit
     "S",
     # flake8-bugbear
     "B",
+    # flake8-builtins
+    "A",
+    # flake8-comprehensions
+    "C4",
     # flake8-debugger
     "T10",
     # flake8-print
     "T20",
     # flake8-simplify
     "SIM",
+    # isort
+    "I",
+    # mccabe
+    "C90",
+    # pycodestyle
+    "E", "W",
+    # pyflakes
+    "F",
     # pygrep-hooks
     "PGH",
     # pyupgrade

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,8 @@ select = [
     "B",
     # flake8-simplify
     "SIM",
+    # pygrep-hooks
+    "PGH",
     # pyupgrade
     "UP",
     # ruff

--- a/tests/imports/test_extract.py
+++ b/tests/imports/test_extract.py
@@ -125,7 +125,6 @@ def test_import_parser_file_encodings_ipynb(code_cell_content: list[str], encodi
   }}
   ]}}"""
             f.write(file_content)
-            print(file_content)
 
         assert get_imported_modules_from_file(Path(random_file_name)) == {"foo"}
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Use `ruff` to replace `pyupgrade` ([almost all rules](https://github.com/charliermarsh/ruff/issues/827) are implemented) and `pygrep-hooks` ([the only rule](https://github.com/charliermarsh/ruff#pygrep-hooks-pgh) we use is implemented, the other are either nice to have, or should not cause any harm).

Also enable more rules that would be nice to have in the codebase, but feel free to tell me if you disagree with some:
- [flake8-2020](https://github.com/charliermarsh/ruff#flake8-2020-ytt)
- [flake8-bandit](https://github.com/charliermarsh/ruff#flake8-bandit-s)
- [flake8-debugger](https://github.com/charliermarsh/ruff#flake8-debugger-t10)
- [flake8-print](https://github.com/charliermarsh/ruff#flake8-print-t20)
- [tryceratops](https://github.com/charliermarsh/ruff#tryceratops-try)