### PR TITLE
chore(ruff): add `from __future__ import annotations` as required import

### DIFF
--- a/deptry/__init__.py
+++ b/deptry/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 logging.getLogger("nbconvert").setLevel(logging.WARNING)

--- a/deptry/compat.py
+++ b/deptry/compat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info >= (3, 8):

--- a/deptry/imports/extractors/__init__.py
+++ b/deptry/imports/extractors/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from deptry.imports.extractors.notebook_import_extractor import NotebookImportExtractor
 from deptry.imports.extractors.python_import_extractor import PythonImportExtractor
 

--- a/deptry/stdlibs.py
+++ b/deptry/stdlibs.py
@@ -4,6 +4,8 @@ It is generated from `scripts/generate_stdlibs.py` script and contains the stdli
 not support https://docs.python.org/3/library/sys.html#sys.stdlib_module_names (< 3.10).
 The file can be generated again using `python scripts/generate_stdlibs.py`.
 """
+from __future__ import annotations
+
 STDLIBS_PYTHON = {
     "37": frozenset(
         {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,5 +141,8 @@ ignore = [
 ]
 extend-exclude = ["tests/data/*"]
 
+[tool.ruff.isort]
+required-imports = ["from __future__ import annotations"]
+
 [tool.ruff.per-file-ignores]
 "tests/*" = ["S101"]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shlex
 import shutil

--- a/tests/cli/test_cli_gitignore.py
+++ b/tests/cli/test_cli_gitignore.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/cli/test_cli_pdm.py
+++ b/tests/cli/test_cli_pdm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/cli/test_cli_pyproject_different_directory.py
+++ b/tests/cli/test_cli_pyproject_different_directory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/cli/test_cli_requirements_txt.py
+++ b/tests/cli/test_cli_requirements_txt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/cli/test_cli_src_directory.py
+++ b/tests/cli/test_cli_src_directory.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import shlex
 import shutil
 import subprocess

--- a/tests/dependency_getter/test_pdm.py
+++ b/tests/dependency_getter/test_pdm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from deptry.dependency_getter.pdm import PDMDependencyGetter

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from deptry.dependency_getter.pep_621 import PEP621DependencyGetter

--- a/tests/dependency_getter/test_poetry.py
+++ b/tests/dependency_getter/test_poetry.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from deptry.dependency_getter.poetry import PoetryDependencyGetter

--- a/tests/dependency_getter/test_requirements_txt.py
+++ b/tests/dependency_getter/test_requirements_txt.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from deptry.dependency_getter.requirements_txt import RequirementsTxtDependencyGetter

--- a/tests/issues_finder/test_misplaced_dev.py
+++ b/tests/issues_finder/test_misplaced_dev.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from deptry.dependency import Dependency
 from deptry.issues_finder.misplaced_dev import MisplacedDevDependenciesFinder
 from deptry.module import Module

--- a/tests/issues_finder/test_obsolete.py
+++ b/tests/issues_finder/test_obsolete.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from deptry.dependency import Dependency
 from deptry.issues_finder.obsolete import ObsoleteDependenciesFinder
 from deptry.module import ModuleBuilder

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 

--- a/tests/test_dependency_specification_detector.py
+++ b/tests/test_dependency_specification_detector.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from pathlib import Path
 

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from pathlib import Path
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from deptry.utils import load_pyproject_toml


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

In order to be able to use generics for typing (`dict`, `list`, `set`, etc.) on Python < 3.9, `from __future__ import annotations` needs to be added. As it can be easy to forget to add it when needed, I thought we could use [`required-imports`](https://github.com/charliermarsh/ruff#required-imports) from Ruff to automatically add it everywhere.