### PR TITLE
chore(ruff): enable `flake8-type-checking`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.0.236"
+    rev: "v0.0.237"
     hooks:
       - id: ruff
 

--- a/deptry/config.py
+++ b/deptry/config.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import logging
-from pathlib import Path
-from typing import Any
-
-import click
+from typing import TYPE_CHECKING, Any
 
 from deptry.utils import load_pyproject_toml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import click
 
 
 def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: Path) -> Path | None:

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -4,10 +4,8 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from deptry.dependency import Dependency
-from deptry.dependency_getter.base import DependenciesExtract
 from deptry.dependency_getter.pdm import PDMDependencyGetter
 from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
 from deptry.dependency_getter.poetry import PoetryDependencyGetter
@@ -20,10 +18,17 @@ from deptry.issues_finder.missing import MissingDependenciesFinder
 from deptry.issues_finder.obsolete import ObsoleteDependenciesFinder
 from deptry.issues_finder.transitive import TransitiveDependenciesFinder
 from deptry.json_writer import JsonWriter
-from deptry.module import Module, ModuleBuilder
+from deptry.module import ModuleBuilder
 from deptry.python_file_finder import PythonFileFinder
 from deptry.result_logger import ResultLogger
 from deptry.stdlibs import STDLIBS_PYTHON
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deptry.dependency import Dependency
+    from deptry.dependency_getter.base import DependenciesExtract
+    from deptry.module import Module
 
 
 @dataclass

--- a/deptry/dependency_getter/base.py
+++ b/deptry/dependency_getter/base.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-from deptry.dependency import Dependency
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deptry.dependency import Dependency
 
 
 @dataclass

--- a/deptry/dependency_getter/pdm.py
+++ b/deptry/dependency_getter/pdm.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract
 from deptry.dependency_getter.pep_621 import PEP621DependencyGetter
 from deptry.utils import load_pyproject_toml
+
+if TYPE_CHECKING:
+    from deptry.dependency import Dependency
 
 
 @dataclass

--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import logging
 import os
 from enum import Enum
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from deptry.exceptions import DependencySpecificationNotFoundError
 from deptry.utils import load_pyproject_toml
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class DependencyManagementFormat(Enum):

--- a/deptry/imports/extract.py
+++ b/deptry/imports/extract.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 import itertools
 import logging
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from deptry.imports.extractors import NotebookImportExtractor, PythonImportExtractor
-from deptry.imports.extractors.base import ImportExtractor
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from deptry.imports.extractors.base import ImportExtractor
 
 
 def get_imported_modules_for_list_of_files(list_of_files: list[Path]) -> list[str]:

--- a/deptry/imports/extractors/base.py
+++ b/deptry/imports/extractors/base.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import ast
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import chardet
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @dataclass

--- a/deptry/imports/extractors/notebook_import_extractor.py
+++ b/deptry/imports/extractors/notebook_import_extractor.py
@@ -6,10 +6,12 @@ import json
 import logging
 import re
 from dataclasses import dataclass
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from deptry.imports.extractors.base import ImportExtractor
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @dataclass

--- a/deptry/issues_finder/base.py
+++ b/deptry/issues_finder/base.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from deptry.dependency import Dependency
-from deptry.module import Module
+if TYPE_CHECKING:
+    from deptry.dependency import Dependency
+    from deptry.module import Module
 
 
 @dataclass

--- a/deptry/issues_finder/misplaced_dev.py
+++ b/deptry/issues_finder/misplaced_dev.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from deptry.issues_finder.base import IssuesFinder
-from deptry.module import Module
+
+if TYPE_CHECKING:
+    from deptry.module import Module
 
 
 @dataclass

--- a/deptry/issues_finder/missing.py
+++ b/deptry/issues_finder/missing.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from deptry.issues_finder.base import IssuesFinder
-from deptry.module import Module
+
+if TYPE_CHECKING:
+    from deptry.module import Module
 
 
 @dataclass

--- a/deptry/issues_finder/obsolete.py
+++ b/deptry/issues_finder/obsolete.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from deptry.dependency import Dependency
 from deptry.issues_finder.base import IssuesFinder
+
+if TYPE_CHECKING:
+    from deptry.dependency import Dependency
 
 
 @dataclass

--- a/deptry/issues_finder/transitive.py
+++ b/deptry/issues_finder/transitive.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from deptry.issues_finder.base import IssuesFinder
-from deptry.module import Module
+
+if TYPE_CHECKING:
+    from deptry.module import Module
 
 
 @dataclass

--- a/deptry/module.py
+++ b/deptry/module.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from deptry.compat import PackageNotFoundError, metadata
-from deptry.dependency import Dependency
+
+if TYPE_CHECKING:
+    from deptry.dependency import Dependency
 
 
 @dataclass

--- a/deptry/utils.py
+++ b/deptry/utils.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from typing import Any
+
 
 from deptry.exceptions import PyprojectFileNotFoundError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ select = [
     "T20",
     # flake8-simplify
     "SIM",
+    # flake8-type-checking
+    "TCH",
     # isort
     "I",
     # mccabe
@@ -140,6 +142,9 @@ ignore = [
     "E731",
 ]
 extend-exclude = ["tests/data/*"]
+
+[tool.ruff.flake8-type-checking]
+strict = true
 
 [tool.ruff.isort]
 required-imports = ["from __future__ import annotations"]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -5,11 +5,14 @@ import shlex
 import shutil
 import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_gitignore.py
+++ b/tests/cli/test_cli_gitignore.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_pdm.py
+++ b/tests/cli/test_cli_pdm.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_pep_621.py
+++ b/tests/cli/test_cli_pep_621.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_pyproject_different_directory.py
+++ b/tests/cli/test_cli_pyproject_different_directory.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_requirements_txt.py
+++ b/tests/cli/test_cli_requirements_txt.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/cli/test_cli_src_directory.py
+++ b/tests/cli/test_cli_src_directory.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
-from _pytest.tmpdir import TempPathFactory
 
 from tests.utils import get_issues_report, run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from _pytest.tmpdir import TempPathFactory
 
 
 @pytest.fixture(scope="session")

--- a/tests/imports/test_extract.py
+++ b/tests/imports/test_extract.py
@@ -3,13 +3,16 @@ from __future__ import annotations
 import logging
 import uuid
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 
 from deptry.imports.extract import get_imported_modules_from_file
 from tests.utils import run_within_dir
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
 
 
 def test_import_parser_py() -> None:

--- a/tests/issues_finder/test_transitive.py
+++ b/tests/issues_finder/test_transitive.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
-from deptry.dependency import Dependency
+from typing import TYPE_CHECKING
+
 from deptry.issues_finder.transitive import TransitiveDependenciesFinder
 from deptry.module import ModuleBuilder
+
+if TYPE_CHECKING:
+    from deptry.dependency import Dependency
 
 
 def test_simple() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
-from _pytest.logging import LogCaptureFixture
 
 from deptry.config import read_configuration_from_pyproject_toml
 from tests.utils import run_within_dir
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
 
 
 def test_read_configuration_from_pyproject_toml_exists(tmp_path: Path) -> None:

--- a/tests/test_json_writer.py
+++ b/tests/test_json_writer.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from deptry.json_writer import JsonWriter
 from tests.utils import run_within_dir
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_simple(tmp_path: Path) -> None:

--- a/tests/test_result_logger.py
+++ b/tests/test_result_logger.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import logging
-
-from _pytest.logging import LogCaptureFixture
+from typing import TYPE_CHECKING
 
 from deptry.result_logger import ResultLogger
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
 
 
 def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Enable rules from https://github.com/snok/flake8-type-checking to detect imports that are only necessary for type checking and need to be moved under `if TYPE_CHECKING` condition.

Combined with `from __future__ import annotations` to not interpret type annotations at runtime, It has the following benefits:
- reducing the import time overhead
- limiting the possibility of ending up with circular imports