### PR TITLE
feat(core): handle local modules without `__init__.py`

### DIFF
--- a/tests/cli/test_cli_src_directory.py
+++ b/tests/cli/test_cli_src_directory.py
@@ -31,7 +31,7 @@ def test_cli_with_src_directory(pep_621_dir_with_src_directory: Path) -> None:
         assert result.returncode == 1
         assert get_issues_report() == {
             "misplaced_dev": [],
-            "missing": ["white"],
+            "missing": ["httpx", "white"],
             "obsolete": ["isort", "requests", "mypy", "pytest"],
             "transitive": [],
         }

--- a/tests/data/project_with_src_directory/pyproject.toml
+++ b/tests/data/project_with_src_directory/pyproject.toml
@@ -19,7 +19,7 @@ dev = [
     "mypy==0.982",
 ]
 test = [
-  "pytest==7.2.0",
+    "pytest==7.2.0",
 ]
 
 [build-system]

--- a/tests/data/project_with_src_directory/src/foobar.py
+++ b/tests/data/project_with_src_directory/src/foobar.py
@@ -1,0 +1,5 @@
+import httpx
+
+
+def another_local_method():
+    ...

--- a/tests/data/project_with_src_directory/src/project_with_src_directory/bar.py
+++ b/tests/data/project_with_src_directory/src/project_with_src_directory/bar.py
@@ -1,1 +1,2 @@
 from project_with_src_directory.foo import a_local_method
+from foobar import another_local_method

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,22 +19,17 @@ from tests.utils import create_files_from_list_of_dicts, run_within_dir
         (
             (),
             "",
-            {"module_with_init"},
-        ),
-        (
-            ("module_without_init",),
-            "",
-            {"module_with_init", "module_without_init"},
+            {"module_with_init", "module_without_init", "local_file"},
         ),
         (
             ("module_with_init", "module_without_init"),
             "",
-            {"module_with_init", "module_without_init"},
+            {"module_with_init", "module_without_init", "local_file"},
         ),
         (
             ("module_without_init",),
             "module_with_init",
-            {"module_without_init", "subdirectory"},
+            {"foo", "module_without_init", "subdirectory"},
         ),
     ],
 )
@@ -47,7 +42,8 @@ def test__get_local_modules(
             {"dir": "module_with_init", "file": "foo.py"},
             {"dir": "module_with_init/subdirectory", "file": "__init__.py"},
             {"dir": "module_with_init/subdirectory", "file": "foo.py"},
-            {"dir": "module_without_init", "file": "foo.py"},
+            {"dir": "module_without_init", "file": "bar.py"},
+            {"dir": ".", "file": "local_file.py"},
         ]
         create_files_from_list_of_dicts(paths)
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Since [PEP 420](https://peps.python.org/pep-0420/), it is not required for Python modules to have an `__init__.py` to be considered a Python module.
We also today only consider directories and not Python files.

This PR handles this case by relaxing `_get_local_modules` method to account for 2 things:
- Directories that don't contain any `__init__.py`, by checking for any Python file
- Files that are Python files (end up with `.py` extension)

Tests have been updated to reflect what this implies for projects using an `src` directory structure.