### PR TITLE
chore(renovate): set schedule up to 5am

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -19,7 +19,7 @@
   labels: ["dependencies"],
 
   // https://docs.renovatebot.com/configuration-options/#schedule
-  schedule: ["before 3am on saturday"],
+  schedule: ["before 5am on saturday"],
 
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

The schedule doesn't always give enough time for Renovate to be triggered, so increasing a bit the max time on the schedule should do the trick.