### PR TITLE
fix(dependency-detector): replace 'PDM' with 'poetry' (typo)

### DIFF
--- a/deptry/dependency_specification_detector.py
+++ b/deptry/dependency_specification_detector.py
@@ -64,7 +64,7 @@ class DependencySpecificationDetector:
             )
         except KeyError:
             logging.debug(
-                "pyproject.toml does not contain a [tool.poetry.dependencies] section, so PDM is not used to specify"
+                "pyproject.toml does not contain a [tool.poetry.dependencies] section, so Poetry is not used to specify"
                 " the project's dependencies."
             )
             return False


### PR DESCRIPTION
**Description of changes**

fixes the typo in #293 

As a security measure, I ran pre-commit and tests with 100% success rate 💪🏼 