### PR TITLE
chore(renovate): set custom changelog URL for `ruff-pre-commit`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -27,6 +27,13 @@
     schedule: ["before 5am on saturday"],
   },
 
+  packageRules: [
+    {
+      matchPackageNames: ["charliermarsh/ruff-pre-commit"],
+      customChangelogUrl: "https://github.com/charliermarsh/ruff",
+    },
+  ],
+
   // https://docs.renovatebot.com/configuration-options/#regexmanagers
   regexManagers: [
     {


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

This allows retrieving release notes from
https://github.com/charliermarsh/ruff/releases, to have actual release notes instead of not having anything.