### PR TITLE
chore(renovate) set `rangeStrategy` to `replace` and pin dev dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1133,4 +1133,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "f31e3f597e9c91561068a8e9be76cd204000e3b9aaa897480ab814da6c4b5c0f"
+content-hash = "57af73feedb3b99858a74bc9b8d5ddef311397b2f7dc2abedac3edfc134c6548"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,16 +30,16 @@ pathspec = ">=0.9.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
 
 [tool.poetry.group.dev.dependencies]
-mypy = "^1.0"
+mypy = "1.2.0"
 # pre-commit 3.x dropped support for Python 3.7.
-pre-commit = { version = "^3.0.0", python = ">=3.8" }
-pytest = "^7.1.2"
-pytest-cov = "^4.0.0"
-types-chardet = "^5.0.4"
+pre-commit = { version = "3.2.2", python = ">=3.8" }
+pytest = "7.3.1"
+pytest-cov = "4.0.0"
+types-chardet = "5.0.4.3"
 
 [tool.poetry.group.docs.dependencies]
-mkdocs = "^1.4.2"
-mkdocs-material = "^9.0.0"
+mkdocs = "1.4.2"
+mkdocs-material = "9.1.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,12 +21,16 @@
   // https://docs.renovatebot.com/configuration-options/#schedule
   schedule: ["before 5am on saturday"],
 
+  // https://docs.renovatebot.com/configuration-options/#rangestrategy
+  rangeStrategy: "replace",
+
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {
     enabled: true,
     schedule: ["before 5am on saturday"],
   },
 
+  // https://docs.renovatebot.com/configuration-options/#packagerules
   packageRules: [
     {
       matchPackageNames: ["charliermarsh/ruff-pre-commit"],


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Renovate v35 updated [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) so that it defaults to `update-lockfile`. This means that it will make pull request to update each dependency separately in the lock file if the update respect the range defined.

Since we already have regular lock files updates that already take care of that, we can only keep this single PR.

The PR also updates dev dependencies to use specific versions instead of ranges. As dev dependencies are only internal, it makes less sense to define a range of accepted dependencies. This will also ensure that we are aware of important changes in minor versions.