### PR TITLE
A way to pre-configure a map of package names to module names

### DIFF
--- a/deptry/core.py
+++ b/deptry/core.py
@@ -24,7 +24,7 @@ from deptry.result_logger import ResultLogger
 from deptry.stdlibs import STDLIBS_PYTHON
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from pathlib import Path
 
     from deptry.dependency import Dependency
@@ -52,7 +52,7 @@ class Core:
     requirements_txt_dev: tuple[str, ...]
     known_first_party: tuple[str, ...]
     json_output: str
-    package_module_name_map: Mapping[str, tuple[str, ...]]
+    package_module_name_map: Mapping[str, Sequence[str]]
 
     def run(self) -> None:
         self._log_config()

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -24,6 +24,7 @@ from deptry.result_logger import ResultLogger
 from deptry.stdlibs import STDLIBS_PYTHON
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from deptry.dependency import Dependency
@@ -51,6 +52,7 @@ class Core:
     requirements_txt_dev: tuple[str, ...]
     known_first_party: tuple[str, ...]
     json_output: str
+    package_module_name_map: Mapping[str, tuple[str, ...]]
 
     def run(self) -> None:
         self._log_config()
@@ -105,13 +107,15 @@ class Core:
 
     def _get_dependencies(self, dependency_management_format: DependencyManagementFormat) -> DependenciesExtract:
         if dependency_management_format is DependencyManagementFormat.POETRY:
-            return PoetryDependencyGetter(self.config).get()
+            return PoetryDependencyGetter(self.config, self.package_module_name_map).get()
         if dependency_management_format is DependencyManagementFormat.PDM:
-            return PDMDependencyGetter(self.config).get()
+            return PDMDependencyGetter(self.config, self.package_module_name_map).get()
         if dependency_management_format is DependencyManagementFormat.PEP_621:
-            return PEP621DependencyGetter(self.config).get()
+            return PEP621DependencyGetter(self.config, self.package_module_name_map).get()
         if dependency_management_format is DependencyManagementFormat.REQUIREMENTS_TXT:
-            return RequirementsTxtDependencyGetter(self.config, self.requirements_txt, self.requirements_txt_dev).get()
+            return RequirementsTxtDependencyGetter(
+                self.config, self.package_module_name_map, self.requirements_txt, self.requirements_txt_dev
+            ).get()
         raise IncorrectDependencyFormatError
 
     def _get_local_modules(self) -> set[str]:

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -14,7 +14,9 @@ class Dependency:
     By default, we also add the dependency's name with '-' replaced by '_' to the top-level modules.
     """
 
-    def __init__(self, name: str, conditional: bool = False, optional: bool = False) -> None:
+    def __init__(
+        self, name: str, conditional: bool = False, optional: bool = False, module_names: tuple[str, ...] | None = None
+    ) -> None:
         """
         Args:
             name: Name of the dependency, as shown in pyproject.toml
@@ -24,12 +26,14 @@ class Dependency:
         self.is_conditional = conditional
         self.is_optional = optional
         self.found = self.find_metadata(name)
-        self.top_levels = self._get_top_levels(name)
+        self.top_levels = self._get_top_levels(name, module_names)
 
-    def _get_top_levels(self, name: str) -> set[str]:
-        top_levels = []
+    def _get_top_levels(self, name: str, module_names: tuple[str, ...] | None) -> set[str]:
+        top_levels: list[str] = []
 
-        if self.found:
+        if module_names is not None:
+            top_levels += module_names
+        elif self.found:
             top_levels += self._get_top_level_module_names_from_top_level_txt()
             if not top_levels:
                 top_levels += self._get_top_level_module_names_from_record_file()

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
 import logging
 import re
+from typing import TYPE_CHECKING
 
 from deptry.compat import PackageNotFoundError, metadata
 
-
 if TYPE_CHECKING:
     from collections.abc import Sequence
+
 
 class Dependency:
     """

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 import logging
 import re
 
 from deptry.compat import PackageNotFoundError, metadata
 
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 class Dependency:
     """
@@ -15,7 +19,7 @@ class Dependency:
     """
 
     def __init__(
-        self, name: str, conditional: bool = False, optional: bool = False, module_names: tuple[str, ...] | None = None
+        self, name: str, conditional: bool = False, optional: bool = False, module_names: Sequence[str] | None = None
     ) -> None:
         """
         Args:
@@ -28,18 +32,18 @@ class Dependency:
         self.found = self.find_metadata(name)
         self.top_levels = self._get_top_levels(name, module_names)
 
-    def _get_top_levels(self, name: str, module_names: tuple[str, ...] | None) -> set[str]:
-        top_levels: list[str] = []
+    def _get_top_levels(self, name: str, module_names: Sequence[str] | None) -> set[str]:
+        top_levels: set[str] = set()
 
         if module_names is not None:
-            top_levels += module_names
+            top_levels.update(module_names)
         elif self.found:
-            top_levels += self._get_top_level_module_names_from_top_level_txt()
+            top_levels.update(self._get_top_level_module_names_from_top_level_txt())
             if not top_levels:
-                top_levels += self._get_top_level_module_names_from_record_file()
+                top_levels.update(self._get_top_level_module_names_from_record_file())
 
-        top_levels.append(name.replace("-", "_").lower())
-        return set(top_levels)
+        top_levels.add(name.replace("-", "_").lower())
+        return top_levels
 
     def __repr__(self) -> str:
         return f"Dependency '{self.name}'"

--- a/deptry/dependency_getter/base.py
+++ b/deptry/dependency_getter/base.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from deptry.dependency import Dependency
@@ -26,6 +27,7 @@ class DependencyGetter(ABC):
     """
 
     config: Path
+    package_module_name_map: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
 
     @abstractmethod
     def get(self) -> DependenciesExtract:

--- a/deptry/dependency_getter/base.py
+++ b/deptry/dependency_getter/base.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
     from pathlib import Path
 
     from deptry.dependency import Dependency
@@ -27,7 +27,7 @@ class DependencyGetter(ABC):
     """
 
     config: Path
-    package_module_name_map: Mapping[str, tuple[str, ...]] = field(default_factory=dict)
+    package_module_name_map: Mapping[str, Sequence[str]] = field(default_factory=dict)
 
     @abstractmethod
     def get(self) -> DependenciesExtract:

--- a/deptry/dependency_getter/pdm.py
+++ b/deptry/dependency_getter/pdm.py
@@ -50,4 +50,4 @@ class PDMDependencyGetter(PEP621DependencyGetter):
         except KeyError:
             logging.debug("No section [tool.pdm.dev-dependencies] found in pyproject.toml")
 
-        return self._extract_pep_508_dependencies(dev_dependency_strings)
+        return self._extract_pep_508_dependencies(dev_dependency_strings, self.package_module_name_map)

--- a/deptry/dependency_getter/pep_621.py
+++ b/deptry/dependency_getter/pep_621.py
@@ -10,7 +10,7 @@ from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
 from deptry.utils import load_pyproject_toml
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 
 @dataclass
@@ -58,7 +58,7 @@ class PEP621DependencyGetter(DependencyGetter):
 
     @classmethod
     def _extract_pep_508_dependencies(
-        cls, dependencies: list[str], package_module_name_map: Mapping[str, tuple[str, ...]]
+        cls, dependencies: list[str], package_module_name_map: Mapping[str, Sequence[str]]
     ) -> list[Dependency]:
         """
         Given a list of dependency specifications (e.g. "django>2.1; os_name != 'nt'"), convert them to Dependency objects.

--- a/deptry/dependency_getter/pep_621.py
+++ b/deptry/dependency_getter/pep_621.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import itertools
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
 from deptry.utils import load_pyproject_toml
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 
 @dataclass
@@ -42,18 +46,20 @@ class PEP621DependencyGetter(DependencyGetter):
     def _get_dependencies(self) -> list[Dependency]:
         pyproject_data = load_pyproject_toml(self.config)
         dependency_strings: list[str] = pyproject_data["project"]["dependencies"]
-        return self._extract_pep_508_dependencies(dependency_strings)
+        return self._extract_pep_508_dependencies(dependency_strings, self.package_module_name_map)
 
     def _get_optional_dependencies(self) -> dict[str, list[Dependency]]:
         pyproject_data = load_pyproject_toml(self.config)
 
         return {
-            group: self._extract_pep_508_dependencies(dependencies)
+            group: self._extract_pep_508_dependencies(dependencies, self.package_module_name_map)
             for group, dependencies in pyproject_data["project"].get("optional-dependencies", {}).items()
         }
 
     @classmethod
-    def _extract_pep_508_dependencies(cls, dependencies: list[str]) -> list[Dependency]:
+    def _extract_pep_508_dependencies(
+        cls, dependencies: list[str], package_module_name_map: Mapping[str, tuple[str, ...]]
+    ) -> list[Dependency]:
         """
         Given a list of dependency specifications (e.g. "django>2.1; os_name != 'nt'"), convert them to Dependency objects.
         """
@@ -64,7 +70,12 @@ class PEP621DependencyGetter(DependencyGetter):
             name = cls._find_dependency_name_in(spec)
             if name:
                 extracted_dependencies.append(
-                    Dependency(name, conditional=cls._is_conditional(spec), optional=cls._is_optional(spec))
+                    Dependency(
+                        name,
+                        conditional=cls._is_conditional(spec),
+                        optional=cls._is_optional(spec),
+                        module_names=package_module_name_map.get(name),
+                    )
                 )
 
         return extracted_dependencies

--- a/deptry/dependency_getter/poetry.py
+++ b/deptry/dependency_getter/poetry.py
@@ -9,7 +9,7 @@ from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
 from deptry.utils import load_pyproject_toml
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 
 @dataclass
@@ -52,7 +52,7 @@ class PoetryDependencyGetter(DependencyGetter):
 
     @classmethod
     def _get_dependencies(
-        cls, poetry_dependencies: dict[str, Any], package_module_name_map: Mapping[str, tuple[str, ...]]
+        cls, poetry_dependencies: dict[str, Any], package_module_name_map: Mapping[str, Sequence[str]]
     ) -> list[Dependency]:
         dependencies = []
         for dep, spec in poetry_dependencies.items():

--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -72,7 +72,12 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
             line = line.replace(name, "")
             optional = self._check_if_dependency_is_optional(line)
             conditional = self._check_if_dependency_is_conditional(line)
-            return Dependency(name=name, optional=optional, conditional=conditional)
+            return Dependency(
+                name=name,
+                optional=optional,
+                conditional=conditional,
+                module_names=self.package_module_name_map.get(name),
+            )
         else:
             return None
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -396,3 +396,51 @@ json_output = "deptry_report.txt"
 ```shell
 deptry . --json-output deptry_report.txt
 ```
+
+#### Manually map Package Names to Top Level Module Names
+
+Deptry will automatically detect top level modules names that belong to a
+module in two ways.
+The first is by inspecting the installed packages. The second is by translating
+the package name to a module name (`foo-bar` translates to `foo_bar`).
+
+This however is not always sufficient. A situation may occur where a package is
+not installed because it is optional and unused in the current installation.
+Then when the package name doesn't directly translate to the top level module
+name, or there are more top level modules names, Deptry may report both
+obsolete packages, and missing packages. A concrete example is deptry reporting obsolete (optional) dependency
+`foo-python`, and missing package `foo`, while package `foo-python` would
+install top level module `foo`, if it were installed.
+
+A solution is to pre-define a mapping between the pacakge name and the top
+level module name(s).
+
+* Type `dict[str, list[str] | str]`
+* Default: `{}`
+* `pyproject.toml` option name: `package_module_name_map`
+* CLI option name: `--package-module-name-map` (short: `-pmnm`)
+* `pyproject.toml` examples:
+```toml
+[tool.deptry.package_module_name_map]
+foo-python = "foo"
+```
+Or for multiple top level module names:
+```toml
+[tool.deptry.package_module_name_map]
+foo-python = [
+    "foo",
+    "bar",
+]
+```
+* CLI examples:
+```shell
+deptry . --package-module-name-map 'foo-python=foo'
+```
+Multiple module names are joined by a pipe (`|`):
+```shell
+deptry . --package-module-name-map 'foo-python=foo|bar'
+```
+Multiple package name to module name mappings are joined by a comma (`,`):
+```shell
+deptry . --package-module-name-map 'foo-python=foo,bar-python=bar'
+```

--- a/tests/cli/test_cli_arg_types.py
+++ b/tests/cli/test_cli_arg_types.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence, Mapping
+from re import Pattern
+
+import click
+import pytest
+from unittest import mock
+
+from deptry.cli import CommaSeparatedMappingParamType, CommaSeparatedTupleParamType
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            "",
+            ("",),
+            id="from empty str",
+        ),
+        pytest.param(
+            "foo",
+            ("foo",),
+            id="from single str",
+        ),
+        pytest.param(
+            "foo,bar",
+            ("foo", "bar"),
+            id="from multiple str",
+        ),
+        pytest.param(
+            [],
+            (),
+            id="from empty list",
+        ),
+        pytest.param(
+            ["foo"],
+            ("foo",),
+            id="from single item list",
+        ),
+        pytest.param(
+            ["foo", "bar"],
+            ("foo", "bar"),
+            id="from multiple item list",
+        ),
+        pytest.param(
+            (),
+            (),
+            id="from empty tuple",
+        ),
+        pytest.param(
+            ("foo",),
+            ("foo",),
+            id="from single item tuple",
+        ),
+        pytest.param(
+            ("foo", "bar"),
+            ("foo", "bar"),
+            id="from multiple item tuple",
+        ),
+    ],
+)
+def test_comma_separated_tuple_param_type_convert(
+    value: str | list[str] | tuple[str, ...],
+    expected: tuple[str, ...],
+) -> None:
+    """Tests all valid conversion paths."""
+    param = mock.Mock(spec=click.Parameter)
+    ctx = mock.Mock(spec=click.Context)
+
+    actual = CommaSeparatedTupleParamType().convert(value=value, param=param, ctx=ctx)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(
+            "foo=bar",
+            {"foo": ("bar",)},
+            id="from str, single key, single value",
+        ),
+        pytest.param(
+            "foo=bar|baz",
+            {"foo": ("bar", "baz")},
+            id="from str, single key, multi value",
+        ),
+        pytest.param(
+            "foo=bar,fox=fuz",
+            {"foo": ("bar",), "fox": ("fuz",)},
+            id="from str, multi key, single value",
+        ),
+        pytest.param(
+            "foo=bar,foo=fuz",
+            {"foo": ("bar", "fuz")},
+            id="from str, redefined key, single value",
+        ),
+        pytest.param(
+            {"foo": "bar"},
+            {"foo": ("bar",)},
+            id="from str-to-str map",
+        ),
+        pytest.param(
+            "foo|bar=baz",
+            {"foo|bar": ("baz",)},
+            id="from str, key with multiple-value separator token",
+        ),
+        pytest.param(
+            "foo=bar=baz",
+            {"foo": ("bar=baz",)},
+            id="from str, single value with key-value seperator token",
+        ),
+        pytest.param(
+            "foo=",
+            {"foo": ("",)},
+            id="from str, empty value",
+        ),
+        pytest.param(
+            {"foo": ("bar",)},
+            {"foo": ("bar",)},
+            id="from str-to-tuple-of-str map",
+        ),
+        pytest.param(
+            {"foo": ("bar",), "bar": "baz"},
+            {"foo": ("bar",), "bar": ("baz",)},
+            id="from str-to-mixed map",
+        ),
+    ],
+)
+def test_comma_separated_mapping_param_type_convert(
+    value: str | Mapping[str, Sequence[str] | str],
+    expected: Mapping[str, tuple[str, ...]],
+) -> None:
+    """Tests all valid conversion paths."""
+    param = mock.Mock(spec=click.Parameter)
+    ctx = mock.Mock(spec=click.Context)
+
+    actual = CommaSeparatedMappingParamType().convert(value=value, param=param, ctx=ctx)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "err_type", "err_msg_matcher"),
+    [
+        pytest.param(
+            "",
+            ValueError,
+            re.compile(r"equal sign"),
+            id="from empty str",
+        ),
+        pytest.param(
+            "foo,bar=baz",
+            ValueError,
+            re.compile(r"equal sign"),
+            id="from invalid first item",
+        ),
+    ],
+)
+def test_comma_separated_mapping_param_type_convert_err(
+    value: str | Mapping[str, Sequence[str] | str],
+    err_type: type[Exception],
+    err_msg_matcher: Pattern[str] | str,
+) -> None:
+    """Tests some invalid conversion paths."""
+    param = mock.Mock(spec=click.Parameter)
+    ctx = mock.Mock(spec=click.Context)
+    param_type = CommaSeparatedMappingParamType()
+
+    with pytest.raises(err_type, match=err_msg_matcher):
+        param_type.convert(value=value, param=param, ctx=ctx)

--- a/tests/cli/test_cli_arg_types.py
+++ b/tests/cli/test_cli_arg_types.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence, Mapping
-from re import Pattern
+from typing import TYPE_CHECKING
+from unittest import mock
 
 import click
 import pytest
-from unittest import mock
 
 from deptry.cli import CommaSeparatedMappingParamType, CommaSeparatedTupleParamType
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+    from re import Pattern
 
 
 @pytest.mark.parametrize(

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -15,6 +15,7 @@ dependencies = [
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
     "conditional-bar>=1.1.0; python_version < 3.11",
+    "fox-python",  # top level module is called "fox"
 ]
 
 [project.optional-dependencies]
@@ -31,9 +32,13 @@ group2 = [
         with open("pyproject.toml", "w") as f:
             f.write(fake_pyproject_toml)
 
-        dependencies = PEP621DependencyGetter(Path("pyproject.toml")).get().dependencies
+        getter = PEP621DependencyGetter(
+            config=Path("pyproject.toml"),
+            package_module_name_map={"fox-python": ("fox",)},
+        )
+        dependencies = getter.get().dependencies
 
-        assert len(dependencies) == 7
+        assert len(dependencies) == 8
 
         assert dependencies[0].name == "foo"
         assert not dependencies[0].is_conditional
@@ -55,17 +60,23 @@ group2 = [
         assert not dependencies[3].is_optional
         assert "conditional_bar" in dependencies[3].top_levels
 
-        assert dependencies[4].name == "foobar"
+        assert dependencies[4].name == "fox-python"
         assert not dependencies[4].is_conditional
         assert not dependencies[4].is_optional
-        assert "foobar" in dependencies[4].top_levels
+        assert "fox_python" in dependencies[4].top_levels
+        assert "fox" in dependencies[4].top_levels
 
-        assert dependencies[5].name == "barfoo"
+        assert dependencies[5].name == "foobar"
         assert not dependencies[5].is_conditional
         assert not dependencies[5].is_optional
-        assert "barfoo" in dependencies[5].top_levels
+        assert "foobar" in dependencies[5].top_levels
 
-        assert dependencies[6].name == "dep"
+        assert dependencies[6].name == "barfoo"
         assert not dependencies[6].is_conditional
         assert not dependencies[6].is_optional
-        assert "dep" in dependencies[6].top_levels
+        assert "barfoo" in dependencies[6].top_levels
+
+        assert dependencies[7].name == "dep"
+        assert not dependencies[7].is_conditional
+        assert not dependencies[7].is_optional
+        assert "dep" in dependencies[7].top_levels

--- a/tests/dependency_getter/test_requirements_txt.py
+++ b/tests/dependency_getter/test_requirements_txt.py
@@ -33,7 +33,7 @@ fox-python
 
         getter = RequirementsTxtDependencyGetter(
             config=Path("pyproject.toml"),
-            package_module_name_map={"fox-python":("fox",)},
+            package_module_name_map={"fox-python": ("fox",)},
         )
         dependencies_extract = getter.get()
         dependencies = dependencies_extract.dependencies

--- a/tests/dependency_getter/test_requirements_txt.py
+++ b/tests/dependency_getter/test_requirements_txt.py
@@ -25,16 +25,20 @@ pytest-cov
 beautifulsoup4
 docopt == 0.6.1
 requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
+fox-python
 """
-
     with run_within_dir(tmp_path):
         with open("requirements.txt", "w") as f:
             f.write(fake_requirements_txt)
 
-        dependencies_extract = RequirementsTxtDependencyGetter(Path("pyproject.toml")).get()
+        getter = RequirementsTxtDependencyGetter(
+            config=Path("pyproject.toml"),
+            package_module_name_map={"fox-python":("fox",)},
+        )
+        dependencies_extract = getter.get()
         dependencies = dependencies_extract.dependencies
 
-        assert len(dependencies) == 17
+        assert len(dependencies) == 18
         assert len(dependencies_extract.dev_dependencies) == 0
 
         assert dependencies[1].name == "colorama"
@@ -51,6 +55,12 @@ requests [security] >= 2.8.1, == 2.8.* ; python_version < "2.7"
         assert dependencies[11].is_conditional
         assert dependencies[11].is_optional
         assert "requests" in dependencies[11].top_levels
+
+        assert dependencies[17].name == "fox-python"
+        assert not dependencies[17].is_conditional
+        assert not dependencies[17].is_optional
+        assert "fox_python" in dependencies[17].top_levels
+        assert "fox" in dependencies[17].top_levels
 
 
 def test_parse_requirements_txt_urls(tmp_path: Path) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -71,6 +71,7 @@ def test__get_local_modules(
                 requirements_txt_dev=(),
                 known_first_party=known_first_party,
                 json_output="",
+                package_module_name_map={},
             )._get_local_modules()
             == expected
         )

--- a/tests/test_dependency.py
+++ b/tests/test_dependency.py
@@ -32,8 +32,9 @@ def test_read_top_level_from_top_level_txt() -> None:
     with patch("deptry.dependency.metadata.distribution") as mock:
         mock.return_value = MockDistribution()
         dependency = Dependency("Foo-bar")
-        assert dependency.name == "Foo-bar"
-        assert dependency.top_levels == {"foo_bar", "foo", "bar"}
+
+    assert dependency.name == "Foo-bar"
+    assert dependency.top_levels == {"foo_bar", "foo", "bar"}
 
 
 def test_read_top_level_from_record() -> None:
@@ -58,5 +59,19 @@ blackd/__main__.py,sha256=<HASH>
     with patch("deptry.dependency.metadata.distribution") as mock:
         mock.return_value = MockDistribution()
         dependency = Dependency("Foo-bar")
-        assert dependency.name == "Foo-bar"
-        assert dependency.top_levels == {"foo_bar", "black", "blackd"}
+
+    assert dependency.name == "Foo-bar"
+    assert dependency.top_levels == {"foo_bar", "black", "blackd"}
+
+
+def test_read_top_level_from_predefined() -> None:
+    """
+    Verify that if there are predefined top-level module names it takes
+    precedence over other lookup methods.
+    """
+    with patch("deptry.dependency.metadata.distribution") as mock:
+        dependency = Dependency("Foo-bar", module_names=["foo"])
+
+    assert dependency.name == "Foo-bar"
+    assert dependency.top_levels == {"foo_bar", "foo"}
+    mock.return_value.read_text.assert_not_called()


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->

Adding a pre-configured map between package names and module names, so not installed modules don't produce errors when a package name doesn't auto-convert to the module name. E.g. package name `foo-python` is translated to module `foo_python`, but it's actually called `foo`.
Fixes https://github.com/fpgmaas/deptry/issues/332

```toml
[tool.deptry.package_module_name_map]
foo-python = [
    "foo",
]
```

Before adding tests & docs, let's see if this is an acceptable problem & solution direction.