### PR TITLE
Only use translated pkg name as fallback + some optimization

### DIFF
--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -100,7 +100,7 @@ class Dependency:
         """
         metadata_top_levels = distribution.read_text("top_level.txt")  # type: ignore[no-untyped-call]
         if metadata_top_levels is None:
-            raise FileNotFoundError("top_levels.txt")
+            raise FileNotFoundError("top_level.txt")
 
         return {x for x in metadata_top_levels.splitlines() if x}
 

--- a/deptry/dependency.py
+++ b/deptry/dependency.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import logging
 import re
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
-from deptry.compat import PackageNotFoundError, metadata
+from deptry.compat import metadata
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -26,24 +27,35 @@ class Dependency:
             name: Name of the dependency, as shown in pyproject.toml
             conditional: boolean to indicate if the dependency is conditional, e.g. 'importlib-metadata': {'version': '*', 'python': '<=3.7'}
         """
+        distribution = self.find_distribution(name)
+
         self.name = name
         self.is_conditional = conditional
         self.is_optional = optional
-        self.found = self.find_metadata(name)
-        self.top_levels = self._get_top_levels(name, module_names)
+        self.found = distribution is not None
+        self.top_levels = self._get_top_levels(name, distribution, module_names)
 
-    def _get_top_levels(self, name: str, module_names: Sequence[str] | None) -> set[str]:
-        top_levels: set[str] = set()
-
+    def _get_top_levels(
+        self, name: str, distribution: metadata.Distribution | None, module_names: Sequence[str] | None
+    ) -> set[str]:
         if module_names is not None:
-            top_levels.update(module_names)
-        elif self.found:
-            top_levels.update(self._get_top_level_module_names_from_top_level_txt())
-            if not top_levels:
-                top_levels.update(self._get_top_level_module_names_from_record_file())
+            return set(module_names)
 
-        top_levels.add(name.replace("-", "_").lower())
-        return top_levels
+        if distribution is not None:
+            with suppress(FileNotFoundError):
+                return self._get_top_level_module_names_from_top_level_txt(distribution)
+
+            with suppress(FileNotFoundError):
+                return self._get_top_level_module_names_from_record_file(distribution)
+
+        # No metadata or other configuration has been found. As a fallback
+        # we'll guess the name.
+        module_name = name.replace("-", "_").lower()
+        logging.warning(
+            f"Assuming the corresponding module name of package {self.name!r} is {module_name!r}. Install the package"
+            " or configure a package_module_name_map entry to override this behaviour."
+        )
+        return {module_name}
 
     def __repr__(self) -> str:
         return f"Dependency '{self.name}'"
@@ -51,17 +63,12 @@ class Dependency:
     def __str__(self) -> str:
         return f"Dependency '{self.name}'{self._string_for_printing()}with top-levels: {self.top_levels}."
 
-    def find_metadata(self, name: str) -> bool:
+    @staticmethod
+    def find_distribution(name: str) -> metadata.Distribution | None:
         try:
-            metadata.distribution(name)  # type: ignore[no-untyped-call]
-        except PackageNotFoundError:
-            logging.warning(
-                f"Warning: Package '{name}'{self._string_for_printing()}not found in current environment. Assuming its"
-                f" corresponding module name is '{name.replace('-','_').lower()}'."
-            )
-            return False
-        else:
-            return True
+            return metadata.distribution(name)
+        except metadata.PackageNotFoundError:
+            return None
 
     def _string_for_printing(self) -> str:
         """
@@ -78,7 +85,8 @@ class Dependency:
         else:
             return " "
 
-    def _get_top_level_module_names_from_top_level_txt(self) -> list[str]:
+    @staticmethod
+    def _get_top_level_module_names_from_top_level_txt(distribution: metadata.Distribution) -> set[str]:
         """
         top-level.txt is a metadata file added by setuptools that looks as follows:
 
@@ -90,37 +98,35 @@ class Dependency:
 
         This function extracts these names, if a top-level.txt file exists.
         """
-        metadata_top_levels = metadata.distribution(self.name).read_text("top_level.txt")  # type: ignore[no-untyped-call]
-        if metadata_top_levels:
-            return [x for x in metadata_top_levels.split("\n") if len(x) > 0]
-        else:
-            return []
+        metadata_top_levels = distribution.read_text("top_level.txt")  # type: ignore[no-untyped-call]
+        if metadata_top_levels is None:
+            raise FileNotFoundError("top_levels.txt")
 
-    def _get_top_level_module_names_from_record_file(self) -> list[str]:
+        return {x for x in metadata_top_levels.splitlines() if x}
+
+    @staticmethod
+    def _get_top_level_module_names_from_record_file(distribution: metadata.Distribution) -> set[str]:
         """
         Get the top-level module names from the RECORD file, whose contents usually look as follows:
 
             ...
+            ../../../bin/black,sha256=<HASH>,247
+            __pycache__/_black_version.cpython-311.pyc,,
+            _black_version.py,sha256=<HASH>,19
             black/trans.cpython-39-darwin.so,sha256=<HASH>
             black/trans.py,sha256=<HASH>
             blackd/__init__.py,sha256=<HASH>
             blackd/__main__.py,sha256=<HASH>
             ...
 
-        So if no file top-level.txt is provided, we can try and extract top-levels from this file, in this case black and blackd.
+        So if no file top-level.txt is provided, we can try and extract top-levels from this file, in
+        this case _black_version, black, and blackd.
         """
-        top_levels = []
-        try:
-            metadata_records = metadata.distribution(self.name).read_text("RECORD")  # type: ignore[no-untyped-call]
+        metadata_records = distribution.read_text("RECORD")  # type: ignore[no-untyped-call]
 
-            if not metadata_records:
-                return []
-        except Exception:
-            return []
+        if metadata_records is None:
+            raise FileNotFoundError("RECORD")
 
-        for line in metadata_records.split("\n"):
-            match = re.match("([a-zA-Z0-9-_]+)/", line)
-            if match:
-                top_levels.append(match.group(1))
+        matches = re.finditer(r"^(?!__)([a-zA-Z0-9-_]+)(?:/|\.py,)", metadata_records, re.MULTILINE)
 
-        return list(set(top_levels))
+        return {x.group(1) for x in matches}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -401,8 +401,9 @@ deptry . --json-output deptry_report.txt
 
 Deptry will automatically detect top level modules names that belong to a
 module in two ways.
-The first is by inspecting the installed packages. The second is by translating
-the package name to a module name (`foo-bar` translates to `foo_bar`).
+The first is by inspecting the installed packages. The second, used as fallback
+for when the package is not installed, is by translating the package name to a
+module name (`Foo-Bar` translates to `foo_bar`).
 
 This however is not always sufficient. A situation may occur where a package is
 not installed because it is optional and unused in the current installation.

--- a/tests/dependency_getter/test_pdm.py
+++ b/tests/dependency_getter/test_pdm.py
@@ -12,7 +12,7 @@ def test_dependency_getter(tmp_path: Path) -> None:
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
 dependencies = [
-    "foo",
+    "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
     "conditional-bar>=1.1.0; python_version < 3.11",
@@ -32,10 +32,10 @@ dependencies = [
 
         assert len(dependencies) == 5
 
-        assert dependencies[0].name == "foo"
+        assert dependencies[0].name == "qux"
         assert not dependencies[0].is_conditional
         assert not dependencies[0].is_optional
-        assert "foo" in dependencies[0].top_levels
+        assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "bar"
         assert not dependencies[1].is_conditional
@@ -55,7 +55,6 @@ dependencies = [
         assert dependencies[4].name == "fox-python"
         assert not dependencies[4].is_conditional
         assert not dependencies[4].is_optional
-        assert "fox_python" in dependencies[4].top_levels
         assert "fox" in dependencies[4].top_levels
 
 
@@ -65,14 +64,14 @@ def test_dev_dependency_getter(tmp_path: Path) -> None:
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
 dependencies = [
-    "foo",
+    "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
     "conditional-bar>=1.1.0; python_version < 3.11",
 ]
 [tool.pdm.dev-dependencies]
 test = [
-    "foo",
+    "qux",
     "bar; python_version < 3.11"
     ]
 tox = [
@@ -88,10 +87,10 @@ tox = [
 
         assert len(dev_dependencies) == 3
 
-        assert dev_dependencies[0].name == "foo"
+        assert dev_dependencies[0].name == "qux"
         assert not dev_dependencies[0].is_conditional
         assert not dev_dependencies[0].is_optional
-        assert "foo" in dev_dependencies[0].top_levels
+        assert "qux" in dev_dependencies[0].top_levels
 
         assert dev_dependencies[1].name == "bar"
         assert dev_dependencies[1].is_conditional

--- a/tests/dependency_getter/test_pep_621.py
+++ b/tests/dependency_getter/test_pep_621.py
@@ -11,7 +11,7 @@ def test_dependency_getter(tmp_path: Path) -> None:
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
 dependencies = [
-    "foo",
+    "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
     "conditional-bar>=1.1.0; python_version < 3.11",
@@ -40,10 +40,10 @@ group2 = [
 
         assert len(dependencies) == 8
 
-        assert dependencies[0].name == "foo"
+        assert dependencies[0].name == "qux"
         assert not dependencies[0].is_conditional
         assert not dependencies[0].is_optional
-        assert "foo" in dependencies[0].top_levels
+        assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "bar"
         assert not dependencies[1].is_conditional
@@ -63,7 +63,6 @@ group2 = [
         assert dependencies[4].name == "fox-python"
         assert not dependencies[4].is_conditional
         assert not dependencies[4].is_optional
-        assert "fox_python" in dependencies[4].top_levels
         assert "fox" in dependencies[4].top_levels
 
         assert dependencies[5].name == "foobar"

--- a/tests/dependency_getter/test_poetry.py
+++ b/tests/dependency_getter/test_poetry.py
@@ -15,7 +15,7 @@ fox-python = "*"  # top level module is called "fox"
 
 [tool.poetry.dev-dependencies]
 toml = "^0.10.2"
-foo =  { version = ">=2.5.1,<4.0.0", optional = true }"""
+qux =  { version = ">=2.5.1,<4.0.0", optional = true }"""
 
     with run_within_dir(tmp_path):
         with open("pyproject.toml", "w") as f:
@@ -45,7 +45,6 @@ foo =  { version = ">=2.5.1,<4.0.0", optional = true }"""
         assert dependencies[2].name == "fox-python"
         assert not dependencies[2].is_conditional
         assert not dependencies[2].is_optional
-        assert "fox_python" in dependencies[2].top_levels
         assert "fox" in dependencies[2].top_levels
 
         assert dev_dependencies[0].name == "toml"
@@ -53,7 +52,7 @@ foo =  { version = ">=2.5.1,<4.0.0", optional = true }"""
         assert not dev_dependencies[0].is_optional
         assert "toml" in dev_dependencies[0].top_levels
 
-        assert dev_dependencies[1].name == "foo"
+        assert dev_dependencies[1].name == "qux"
         assert not dev_dependencies[1].is_conditional
         assert dev_dependencies[1].is_optional
-        assert "foo" in dev_dependencies[1].top_levels
+        assert "qux" in dev_dependencies[1].top_levels

--- a/tests/dependency_getter/test_requirements_txt.py
+++ b/tests/dependency_getter/test_requirements_txt.py
@@ -59,7 +59,6 @@ fox-python
         assert dependencies[17].name == "fox-python"
         assert not dependencies[17].is_conditional
         assert not dependencies[17].is_optional
-        assert "fox_python" in dependencies[17].top_levels
         assert "fox" in dependencies[17].top_levels
 
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**
It should have been split across multiple PRs, but I'm trying it like this anyway:

* The translated package name is now only added to the recognized top level modules if no mapping or metadata is found.
* If a metadata file is found, but it's empty, no alternative methods of finding top level module names will be tried. Previously no distinction was made between not found and found but empty.
* optimized the code a bit to reduce the up to three `metadata.distribution(name)` calls to one.
* recognize more top level module names in RECORDS file ("foo.py,..." is now recognized as "foo", in accordance to the top_level.txt provided names)
* remove "\_\_pycache__" from recognized names in RECORDS file

:rotating_light: not adding the translated package name by default may, but in practice should not, break things.
:rotating_light: removed public instance method `Dependency::find_metadata`

In the test file you'll find changes where package "foo" has been renamed to "qux". This is because it was not meant to collide with a package "foo" defined in `tests/data/project_with_src_directory`, but does, while that package has no top level module "foo". Due to the translated package name no longer being added, this now resulted "foo" missing in the top level module names. 

**Context**
fixes https://github.com/fpgmaas/deptry/issues/335
fixes https://github.com/fpgmaas/deptry/issues/336
