### PR TITLE
exclude some lines from coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,25 @@ preview = true
 
 [tool.coverage.report]
 skip_empty = true
+exclude_lines = [
+    # a more strict default pragma
+    "# pragma: no cover\\b",
+
+    # allow defensive code
+    "^\\s*raise AssertionError\\b",
+    "^\\s*raise NotImplementedError\\b",
+    "^\\s*return NotImplemented\\b",
+    "^\\s*raise$",
+
+    # typing-related code
+    "^\\s*if (False|TYPE_CHECKING):",
+    ": \\.\\.\\.(\\s*#.*)?$",
+    "^ +\\.\\.\\.$",
+    "-> ['\"]?NoReturn['\"]?:",
+
+    # non-runnable code
+    "if __name__ == ['\"]__main__['\"]:$",
+]
 
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ preview = true
 
 [tool.coverage.report]
 skip_empty = true
+# Subset of rules from https://pypi.org/project/covdefaults/
 exclude_lines = [
     # a more strict default pragma
     "# pragma: no cover\\b",


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

<!-- Please state what you've changed and how it might affect the user. -->
I noticed that a test fails in https://github.com/fpgmaas/deptry/pull/333 due to a coverage delta being too negative. It is induced by `if TYPE_CHECKING:` blocks, which should be ok.
This PR suggests some lines of code that may be excluded from coverage, as they generally are not ment to. It's a subset of what's suggested to be a good default by the [covdefaults](https://pypi.org/project/covdefaults/) library.