### PR TITLE
chore: remove `tox` from CI

### DIFF
--- a/.github/actions/setup-poetry-env/action.yml
+++ b/.github/actions/setup-poetry-env/action.yml
@@ -16,9 +16,25 @@ runs:
         python-version: ${{ inputs.python-version }}
 
     - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-in-project: true
+      env:
+        # renovate: datasource=pypi depName=poetry
+        POETRY_VERSION: "1.4.2"
+      run: curl -sSL https://install.python-poetry.org | python - -y
+      shell: bash
+
+    - name: Add Poetry to Path
+      run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      if: ${{ matrix.os != 'Windows' }}
+      shell: bash
+
+    - name: Add Poetry to Path
+      run: echo "$APPDATA\Python\Scripts" >> $GITHUB_PATH
+      if: ${{ matrix.os == 'Windows' }}
+      shell: bash
+
+    - name: Configure Poetry virtual environment in project
+      run: poetry config virtualenvs.in-project true
+      shell: bash
 
     - name: Load cached venv
       id: cached-poetry-dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
       - name: Load cached venv
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,10 @@
 name: Main
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
 
 jobs:
   quality:
@@ -31,7 +30,7 @@ jobs:
       - name: Check Poetry lock file consistency
         run: poetry lock --check
 
-  tox:
+  tests-and-type-check:
     runs-on: ${{ matrix.image }}
     strategy:
       matrix:
@@ -52,25 +51,16 @@ jobs:
       - name: Check out
         uses: actions/checkout@v3
 
-      - name: Set up python
-        uses: actions/setup-python@v4
+      - name: Set up the environment
+        uses: ./.github/actions/setup-poetry-env
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
+      - name: Run tests
+        run: poetry run pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
 
-      - name: Load cached venv
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          key: venv-${{ runner.os }}-${{ matrix.image }}-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}
-
-      - name: Install tox
-        run: python -m pip install "tox-gh-actions==3.1.0" # renovate: pep440-python-dependency
-
-      - name: Test with tox
-        run: tox
+      - name: Check typing
+        run: poetry run mypy
 
       - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11 for Ubuntu
         uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ ignore_missing = ["tomllib"]
 deptry = "deptry.cli:deptry"
 
 [tool.pytest.ini_options]
+addopts = "--doctest-modules"
 norecursedirs = ["data*"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,9 @@ ignore_missing = ["tomllib"]
 [tool.poetry.scripts]
 deptry = "deptry.cli:deptry"
 
+[tool.pytest.ini_options]
+norecursedirs = ["data*"]
+
 [tool.ruff]
 target-version = "py38"
 line-length = 120

--- a/tox.ini
+++ b/tox.ini
@@ -2,13 +2,6 @@
 skipsdist = true
 envlist = py38, py39, py310, py311
 
-[gh-actions]
-python =
-    3.8: py38
-    3.9: py39
-    3.10: py310
-    3.11: py311
-
 [testenv]
 allowlist_externals = poetry
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -14,5 +14,5 @@ allowlist_externals = poetry
 skip_install = true
 commands_pre = poetry install
 commands =
-    poetry run pytest --doctest-modules tests --cov --cov-config=pyproject.toml --cov-report=xml
+    poetry run pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
     poetry run mypy

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ allowlist_externals = poetry
 skip_install = true
 commands_pre = poetry install
 commands =
-    poetry run pytest tests --cov --cov-config=pyproject.toml --cov-report=xml
+    poetry run pytest
     poetry run mypy

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
     3.11: py311
 
 [testenv]
-deps = poetry
+allowlist_externals = poetry
 skip_install = true
 commands_pre = poetry install
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,3 @@ commands_pre = poetry install
 commands =
     poetry run pytest --doctest-modules tests --cov --cov-config=pyproject.toml --cov-report=xml
     poetry run mypy
-
-[pytest]
-norecursedirs = data*


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

https://github.com/fpgmaas/deptry/pull/364 fails because Poetry is installed in the same environment as dependencies by tox, following the changes in https://github.com/fpgmaas/deptry/pull/342.

I originally intended to keep using `allowlist_externals` to maintain a separation between Poetry and the environment, but I couldn't make it work on Windows.

As it seems using `tox` doesn't bring that much values on the CI, and actually adds a bit of complexity, I figured we could remove it entirely. I still think we could keep it locally for developers that wish to run tests and type checking on all versions, but if we think it's worth removing as well, I don't mind removing it as well.

Note that for some reason, running `poetry` commands in `pytest` also didn't work well on Windows with the current way of installing Poetry, as Windows was not able to find the executable, even if it's supposed to be added to the `PATH`. Using the official installer made it work though, and we can do most of what the actions does manually in the end, so I figured we could drop the action entirely.

https://github.com/mkniewallner/deptry/pull/25 shows that this indeed fix the failure in https://github.com/fpgmaas/deptry/pull/364.