### PR TITLE
feat: add colours to text output

### DIFF
--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -120,6 +120,11 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     default="pyproject.toml",
 )
 @click.option(
+    "--no-ansi",
+    is_flag=True,
+    help="Disable ANSI characters in terminal output.",
+)
+@click.option(
     "--skip-obsolete",
     is_flag=True,
     help="Boolean flag to specify if deptry should skip scanning the project for obsolete dependencies.",
@@ -259,6 +264,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
 def deptry(
     root: Path,
     config: Path,
+    no_ansi: bool,
     ignore_obsolete: tuple[str, ...],
     ignore_missing: tuple[str, ...],
     ignore_transitive: tuple[str, ...],
@@ -286,6 +292,7 @@ def deptry(
     Core(
         root=root,
         config=config,
+        no_ansi=no_ansi,
         ignore_obsolete=ignore_obsolete,
         ignore_missing=ignore_missing,
         ignore_transitive=ignore_transitive,

--- a/deptry/cli.py
+++ b/deptry/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from collections import defaultdict
 from importlib.metadata import version
 from pathlib import Path
@@ -13,6 +14,11 @@ from deptry.core import Core
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+
+if sys.platform == "win32":
+    from colorama import just_fix_windows_console
+
+    just_fix_windows_console()
 
 DEFAULT_EXCLUDE = ("venv", r"\.venv", r"\.direnv", "tests", r"\.git", r"setup\.py")
 

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 class Core:
     root: Path
     config: Path
+    no_ansi: bool
     ignore_obsolete: tuple[str, ...]
     ignore_missing: tuple[str, ...]
     ignore_transitive: tuple[str, ...]

--- a/deptry/core.py
+++ b/deptry/core.py
@@ -89,7 +89,7 @@ class Core:
         ]
 
         violations = self._find_violations(imported_modules_with_locations, dependencies_extract.dependencies)
-        TextReporter(violations).report()
+        TextReporter(violations, use_ansi=not self.no_ansi).report()
 
         if self.json_output:
             JSONReporter(violations, self.json_output).report()

--- a/deptry/imports/location.py
+++ b/deptry/imports/location.py
@@ -12,8 +12,3 @@ class Location:
     file: Path
     line: int | None = None
     column: int | None = None
-
-    def format_for_terminal(self) -> str:
-        if self.line is not None and self.column is not None:
-            return f"{self.file}:{self.line}:{self.column}"
-        return str(self.file)

--- a/deptry/reporters/text.py
+++ b/deptry/reporters/text.py
@@ -2,12 +2,23 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from deptry.reporters.base import Reporter
 
 if TYPE_CHECKING:
+    from deptry.imports.location import Location
     from deptry.violations import Violation
+
+
+COLORS = {
+    "BOLD": "\033[1m",
+    "CYAN": "\033[36m",
+    "GREEN": "\033[32m",
+    "RED": "\033[31m",
+    "RESET": "\033[m",
+}
+COLORS_NOOP = {color: "" for color in COLORS}
 
 
 @dataclass
@@ -22,13 +33,18 @@ class TextReporter(Reporter):
 
         self._log_total_number_of_violations_found(self.violations)
 
-    @staticmethod
-    def _log_total_number_of_violations_found(violations: list[Violation]) -> None:
+    def _log_total_number_of_violations_found(self, violations: list[Violation]) -> None:
         if violations:
-            logging.info(f"Found {len(violations)} dependency {'issues' if len(violations) > 1 else 'issue'}.")
+            logging.info(
+                self._stylize(
+                    "{BOLD}{RED}Found {total} dependency {issue_word}.{RESET}",
+                    total=len(violations),
+                    issue_word="issues" if len(violations) > 1 else "issue",
+                )
+            )
             logging.info("\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/")
         else:
-            logging.info("Success! No dependency issues found.")
+            logging.info(self._stylize("{BOLD}{GREEN}Success! No dependency issues found.{RESET}"))
 
     def _log_violations(self, violations: list[Violation]) -> None:
         logging.info("")
@@ -36,6 +52,26 @@ class TextReporter(Reporter):
         for violation in violations:
             logging.info(self._format_error(violation))
 
-    @classmethod
-    def _format_error(cls, violation: Violation) -> str:
-        return f"{(violation.location.format_for_terminal())}: {violation.error_code} {violation.get_error_message()}"
+    def _format_error(self, violation: Violation) -> str:
+        return self._stylize(
+            "{location}{CYAN}:{RESET} {BOLD}{RED}{error_code}{RESET} {error_message}",
+            location=self._format_location(violation.location),
+            error_code=violation.error_code,
+            error_message=violation.get_error_message(),
+        )
+
+    def _format_location(self, location: Location) -> str:
+        if location.line is not None and location.column is not None:
+            return self._stylize(
+                "{BOLD}{file}{RESET}{CYAN}:{RESET}{line}{CYAN}:{RESET}{column}",
+                file=location.file,
+                line=location.line,
+                column=location.column,
+            )
+        return self._stylize("{BOLD}{file}{RESET}", file=location.file)
+
+    def _stylize(self, text: str, **kwargs: Any) -> str:
+        return text.format(**kwargs, **self._get_colors())
+
+    def _get_colors(self) -> dict[str, str]:
+        return COLORS if self.use_ansi else COLORS_NOOP

--- a/deptry/reporters/text.py
+++ b/deptry/reporters/text.py
@@ -12,6 +12,8 @@ if TYPE_CHECKING:
 
 @dataclass
 class TextReporter(Reporter):
+    use_ansi: bool = True
+
     def report(self) -> None:
         self._log_and_exit()
 

--- a/deptry/violations/misplaced_dev.py
+++ b/deptry/violations/misplaced_dev.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @dataclass
 class MisplacedDevDependencyViolation(Violation):
     error_code: ClassVar[str] = "DEP004"
-    error_template: ClassVar[str] = "{name} imported but declared as a dev dependency"
+    error_template: ClassVar[str] = "'{name}' imported but declared as a dev dependency"
     issue: Module
 
     def get_error_message(self) -> str:

--- a/deptry/violations/missing.py
+++ b/deptry/violations/missing.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @dataclass
 class MissingDependencyViolation(Violation):
     error_code: ClassVar[str] = "DEP001"
-    error_template: ClassVar[str] = "{name} imported but missing from the dependency definitions"
+    error_template: ClassVar[str] = "'{name}' imported but missing from the dependency definitions"
     issue: Module
 
     def get_error_message(self) -> str:

--- a/deptry/violations/obsolete.py
+++ b/deptry/violations/obsolete.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @dataclass
 class ObsoleteDependencyViolation(Violation):
     error_code: ClassVar[str] = "DEP002"
-    error_template: ClassVar[str] = "{name} defined as a dependency but not used in the codebase"
+    error_template: ClassVar[str] = "'{name}' defined as a dependency but not used in the codebase"
     issue: Dependency
 
     def get_error_message(self) -> str:

--- a/deptry/violations/transitive.py
+++ b/deptry/violations/transitive.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 @dataclass
 class TransitiveDependencyViolation(Violation):
     error_code: ClassVar[str] = "DEP003"
-    error_template: ClassVar[str] = "{name} imported but it is a transitive dependency"
+    error_template: ClassVar[str] = "'{name}' imported but it is a transitive dependency"
     issue: Module
 
     def get_error_message(self) -> str:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -117,6 +117,18 @@ Path to the `pyproject.toml` file that holds _deptry_'s configuration and depend
 deptry . --config sub_directory/pyproject.toml
 ```
 
+#### No ANSI
+
+Disable ANSI characters in terminal output.
+
+- Type: `bool`
+- Default: `False`
+- CLI option name: `--no-ansi`
+- CLI example:
+```shell
+deptry . --no-ansi
+```
+
 #### Exclude
 
 List of patterns to exclude when searching for source files.

--- a/poetry.lock
+++ b/poetry.lock
@@ -983,6 +983,18 @@ files = [
 ]
 
 [[package]]
+name = "types-colorama"
+version = "0.4.15.11"
+description = "Typing stubs for colorama"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-colorama-0.4.15.11.tar.gz", hash = "sha256:a9421eb24d9cfc584880dc1d33b7fd406a14227c1f99f50c5ab9265e04d07638"},
+    {file = "types_colorama-0.4.15.11-py3-none-any.whl", hash = "sha256:d1e37571a19e152c930b3e789c316e9332e51a43bfcd4470b98225be974fb90c"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.5.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1092,4 +1104,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "6ac0b19f6d2552027ceb837d25370b61ba938190df6a5e78e337e38e3ddf0df5"
+content-hash = "159af32c77d65dddd6eb4c2ab0ee8d0b908978b1075114cd09e60e50da228043"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 python = ">=3.8,<4.0"
 chardet = ">=4.0.0"
 click = "^8.0.0"
+colorama = { version = ">=0.4.6", markers = "sys_platform == 'win32'" }
 pathspec = ">=0.9.0"
 tomli = { version = "^2.0.1", python = "<3.11" }
 
@@ -34,6 +35,7 @@ pre-commit = "3.3.1"
 pytest = "7.3.1"
 pytest-cov = "4.0.0"
 types-chardet = "5.0.4.5"
+types-colorama = { version = "0.4.15.11", markers = "sys_platform == 'win32'" }
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "1.4.3"

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -24,7 +24,7 @@ def test_cli_returns_error(poetry_project_builder: ToolSpecificProjectBuilder) -
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -36,7 +36,7 @@ def test_cli_returns_error(poetry_project_builder: ToolSpecificProjectBuilder) -
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -48,7 +48,7 @@ def test_cli_returns_error(poetry_project_builder: ToolSpecificProjectBuilder) -
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -60,7 +60,7 @@ def test_cli_returns_error(poetry_project_builder: ToolSpecificProjectBuilder) -
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -81,7 +81,7 @@ def test_cli_ignore_notebooks(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "toml defined as a dependency but not used in the codebase",
+                    "message": "'toml' defined as a dependency but not used in the codebase",
                 },
                 "module": "toml",
                 "location": {
@@ -93,7 +93,7 @@ def test_cli_ignore_notebooks(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -105,7 +105,7 @@ def test_cli_ignore_notebooks(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -117,7 +117,7 @@ def test_cli_ignore_notebooks(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -129,7 +129,7 @@ def test_cli_ignore_notebooks(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -164,7 +164,7 @@ def test_cli_exclude(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "toml defined as a dependency but not used in the codebase",
+                    "message": "'toml' defined as a dependency but not used in the codebase",
                 },
                 "module": "toml",
                 "location": {
@@ -176,7 +176,7 @@ def test_cli_exclude(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -188,7 +188,7 @@ def test_cli_exclude(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -200,7 +200,7 @@ def test_cli_exclude(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -212,7 +212,7 @@ def test_cli_exclude(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -233,7 +233,7 @@ def test_cli_extend_exclude(project_builder: ToolSpecificProjectBuilder) -> None
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "toml defined as a dependency but not used in the codebase",
+                    "message": "'toml' defined as a dependency but not used in the codebase",
                 },
                 "module": "toml",
                 "location": {
@@ -245,7 +245,7 @@ def test_cli_extend_exclude(project_builder: ToolSpecificProjectBuilder) -> None
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -257,7 +257,7 @@ def test_cli_extend_exclude(project_builder: ToolSpecificProjectBuilder) -> None
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -269,7 +269,7 @@ def test_cli_extend_exclude(project_builder: ToolSpecificProjectBuilder) -> None
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -281,7 +281,7 @@ def test_cli_extend_exclude(project_builder: ToolSpecificProjectBuilder) -> None
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -302,7 +302,7 @@ def test_cli_known_first_party(project_builder: ToolSpecificProjectBuilder) -> N
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -314,7 +314,7 @@ def test_cli_known_first_party(project_builder: ToolSpecificProjectBuilder) -> N
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -326,7 +326,7 @@ def test_cli_known_first_party(project_builder: ToolSpecificProjectBuilder) -> N
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -348,7 +348,7 @@ def test_cli_not_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -360,7 +360,7 @@ def test_cli_not_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -372,7 +372,7 @@ def test_cli_not_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -384,7 +384,7 @@ def test_cli_not_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -408,7 +408,7 @@ def test_cli_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -420,7 +420,7 @@ def test_cli_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -432,7 +432,7 @@ def test_cli_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -444,7 +444,7 @@ def test_cli_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -467,10 +467,10 @@ def test_cli_with_not_json_output(project_builder: ToolSpecificProjectBuilder) -
         assert len(list(Path(".").glob("*.json"))) == 0
         assert (
             result.stderr
-            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 isort defined as a dependency but not"
-            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 requests defined as a dependency but not"
-            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 black imported but declared as a dev"
-            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 white imported but missing from the dependency"
+            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 'isort' defined as a dependency but not"
+            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 'requests' defined as a dependency but not"
+            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 'black' imported but declared as a dev"
+            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 'white' imported but missing from the dependency"
             " definitions\nFound 4 dependency issues.\n\nFor more information, see the documentation:"
             " https://fpgmaas.github.io/deptry/\n"
         )
@@ -483,10 +483,10 @@ def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> No
         # Assert that we still write to console when generating a JSON report.
         assert (
             result.stderr
-            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 isort defined as a dependency but not"
-            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 requests defined as a dependency but not"
-            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 black imported but declared as a dev"
-            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 white imported but missing from the dependency"
+            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 'isort' defined as a dependency but not"
+            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 'requests' defined as a dependency but not"
+            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 'black' imported but declared as a dev"
+            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 'white' imported but missing from the dependency"
             " definitions\nFound 4 dependency issues.\n\nFor more information, see the documentation:"
             " https://fpgmaas.github.io/deptry/\n"
         )
@@ -494,7 +494,7 @@ def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -506,7 +506,7 @@ def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -518,7 +518,7 @@ def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -530,7 +530,7 @@ def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from click.testing import CliRunner
 
 from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report, run_within_dir, stylize
 
 if TYPE_CHECKING:
     from tests.functional.types import ToolSpecificProjectBuilder
@@ -456,6 +456,27 @@ def test_cli_verbose(project_builder: ToolSpecificProjectBuilder) -> None:
         ]
 
 
+def test_cli_with_no_ansi(project_builder: ToolSpecificProjectBuilder) -> None:
+    with run_within_dir(project_builder("example_project", "poetry install --no-interaction --no-root")):
+        result = subprocess.run(shlex.split("poetry run deptry . --no-ansi"), capture_output=True, text=True)
+
+        expected_output = [
+            "Scanning 2 files...",
+            "",
+            f"{Path('pyproject.toml')}: DEP002 'isort' defined as a dependency but not used in the codebase",
+            f"{Path('pyproject.toml')}: DEP002 'requests' defined as a dependency but not used in the codebase",
+            f"{Path('src/main.py')}:4:0: DEP004 'black' imported but declared as a dev dependency",
+            f"{Path('src/main.py')}:6:0: DEP001 'white' imported but missing from the dependency definitions",
+            "Found 4 dependency issues.",
+            "",
+            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "",
+        ]
+
+        assert result.returncode == 1
+        assert result.stderr == "\n".join(expected_output)
+
+
 def test_cli_with_not_json_output(project_builder: ToolSpecificProjectBuilder) -> None:
     with run_within_dir(project_builder("example_project", "poetry install --no-interaction --no-root")):
         # Remove previously generated `report.json`.
@@ -463,33 +484,91 @@ def test_cli_with_not_json_output(project_builder: ToolSpecificProjectBuilder) -
 
         result = subprocess.run(shlex.split("poetry run deptry ."), capture_output=True, text=True)
 
+        expected_output = [
+            "Scanning 2 files...",
+            "",
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET} {BOLD}{RED}DEP002{RESET} 'isort' defined as a dependency but not"
+                    " used in the codebase"
+                ),
+                file=Path("pyproject.toml"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET} {BOLD}{RED}DEP002{RESET} 'requests' defined as a dependency but"
+                    " not used in the codebase"
+                ),
+                file=Path("pyproject.toml"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET}4{CYAN}:{RESET}0{CYAN}:{RESET} {BOLD}{RED}DEP004{RESET} 'black'"
+                    " imported but declared as a dev dependency"
+                ),
+                file=Path("src/main.py"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET}6{CYAN}:{RESET}0{CYAN}:{RESET} {BOLD}{RED}DEP001{RESET} 'white'"
+                    " imported but missing from the dependency definitions"
+                ),
+                file=Path("src/main.py"),
+            ),
+            stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
+            "",
+            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "",
+        ]
+
         assert result.returncode == 1
         assert len(list(Path(".").glob("*.json"))) == 0
-        assert (
-            result.stderr
-            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 'isort' defined as a dependency but not"
-            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 'requests' defined as a dependency but not"
-            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 'black' imported but declared as a dev"
-            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 'white' imported but missing from the dependency"
-            " definitions\nFound 4 dependency issues.\n\nFor more information, see the documentation:"
-            " https://fpgmaas.github.io/deptry/\n"
-        )
+        assert result.stderr == "\n".join(expected_output)
 
 
 def test_cli_with_json_output(project_builder: ToolSpecificProjectBuilder) -> None:
     with run_within_dir(project_builder("example_project", "poetry install --no-interaction --no-root")):
         result = subprocess.run(shlex.split("poetry run deptry . -o deptry.json"), capture_output=True, text=True)
 
+        expected_output = [
+            "Scanning 2 files...",
+            "",
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET} {BOLD}{RED}DEP002{RESET} 'isort' defined as a dependency but not"
+                    " used in the codebase"
+                ),
+                file=Path("pyproject.toml"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET} {BOLD}{RED}DEP002{RESET} 'requests' defined as a dependency but"
+                    " not used in the codebase"
+                ),
+                file=Path("pyproject.toml"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET}4{CYAN}:{RESET}0{CYAN}:{RESET} {BOLD}{RED}DEP004{RESET} 'black'"
+                    " imported but declared as a dev dependency"
+                ),
+                file=Path("src/main.py"),
+            ),
+            stylize(
+                (
+                    "{BOLD}{file}{RESET}{CYAN}:{RESET}6{CYAN}:{RESET}0{CYAN}:{RESET} {BOLD}{RED}DEP001{RESET} 'white'"
+                    " imported but missing from the dependency definitions"
+                ),
+                file=Path("src/main.py"),
+            ),
+            stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
+            "",
+            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "",
+        ]
+
         # Assert that we still write to console when generating a JSON report.
-        assert (
-            result.stderr
-            == f"Scanning 2 files...\n\n{str(Path('pyproject.toml'))}: DEP002 'isort' defined as a dependency but not"
-            f" used in the codebase\n{str(Path('pyproject.toml'))}: DEP002 'requests' defined as a dependency but not"
-            f" used in the codebase\n{str(Path('src/main.py'))}:4:0: DEP004 'black' imported but declared as a dev"
-            f" dependency\n{str(Path('src/main.py'))}:6:0: DEP001 'white' imported but missing from the dependency"
-            " definitions\nFound 4 dependency issues.\n\nFor more information, see the documentation:"
-            " https://fpgmaas.github.io/deptry/\n"
-        )
+        assert result.stderr == "\n".join(expected_output)
         assert get_issues_report("deptry.json") == [
             {
                 "error": {

--- a/tests/functional/cli/test_cli_gitignore.py
+++ b/tests/functional/cli/test_cli_gitignore.py
@@ -22,7 +22,7 @@ def test_cli_gitignore_is_used(pip_project_builder: ToolSpecificProjectBuilder) 
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -34,7 +34,7 @@ def test_cli_gitignore_is_used(pip_project_builder: ToolSpecificProjectBuilder) 
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "mypy defined as a dependency but not used in the codebase",
+                    "message": "'mypy' defined as a dependency but not used in the codebase",
                 },
                 "module": "mypy",
                 "location": {
@@ -46,7 +46,7 @@ def test_cli_gitignore_is_used(pip_project_builder: ToolSpecificProjectBuilder) 
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "pytest defined as a dependency but not used in the codebase",
+                    "message": "'pytest' defined as a dependency but not used in the codebase",
                 },
                 "module": "pytest",
                 "location": {
@@ -67,7 +67,7 @@ def test_cli_gitignore_is_not_used(pip_project_builder: ToolSpecificProjectBuild
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -79,7 +79,7 @@ def test_cli_gitignore_is_not_used(pip_project_builder: ToolSpecificProjectBuild
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -91,7 +91,7 @@ def test_cli_gitignore_is_not_used(pip_project_builder: ToolSpecificProjectBuild
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "pytest defined as a dependency but not used in the codebase",
+                    "message": "'pytest' defined as a dependency but not used in the codebase",
                 },
                 "module": "pytest",
                 "location": {

--- a/tests/functional/cli/test_cli_pdm.py
+++ b/tests/functional/cli/test_cli_pdm.py
@@ -21,7 +21,7 @@ def test_cli_with_pdm(pdm_project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -33,7 +33,7 @@ def test_cli_with_pdm(pdm_project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -45,7 +45,7 @@ def test_cli_with_pdm(pdm_project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -57,7 +57,7 @@ def test_cli_with_pdm(pdm_project_builder: ToolSpecificProjectBuilder) -> None:
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/functional/cli/test_cli_pep_621.py
+++ b/tests/functional/cli/test_cli_pep_621.py
@@ -21,7 +21,7 @@ def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -33,7 +33,7 @@ def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -45,7 +45,7 @@ def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "mypy defined as a dependency but not used in the codebase",
+                    "message": "'mypy' defined as a dependency but not used in the codebase",
                 },
                 "module": "mypy",
                 "location": {
@@ -57,7 +57,7 @@ def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "pytest defined as a dependency but not used in the codebase",
+                    "message": "'pytest' defined as a dependency but not used in the codebase",
                 },
                 "module": "pytest",
                 "location": {
@@ -69,7 +69,7 @@ def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> No
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/functional/cli/test_cli_pyproject_different_directory.py
+++ b/tests/functional/cli/test_cli_pyproject_different_directory.py
@@ -21,7 +21,7 @@ def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecifi
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -33,7 +33,7 @@ def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecifi
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -45,7 +45,7 @@ def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecifi
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "mypy defined as a dependency but not used in the codebase",
+                    "message": "'mypy' defined as a dependency but not used in the codebase",
                 },
                 "module": "mypy",
                 "location": {
@@ -57,7 +57,7 @@ def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecifi
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "pytest defined as a dependency but not used in the codebase",
+                    "message": "'pytest' defined as a dependency but not used in the codebase",
                 },
                 "module": "pytest",
                 "location": {
@@ -69,7 +69,7 @@ def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecifi
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/functional/cli/test_cli_requirements_txt.py
+++ b/tests/functional/cli/test_cli_requirements_txt.py
@@ -24,7 +24,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -36,7 +36,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -48,7 +48,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -60,7 +60,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {
@@ -72,7 +72,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP003",
-                    "message": "urllib3 imported but it is a transitive dependency",
+                    "message": "'urllib3' imported but it is a transitive dependency",
                 },
                 "module": "urllib3",
                 "location": {
@@ -84,7 +84,7 @@ def test_cli_single_requirements_txt(requirements_txt_project_builder: ToolSpeci
             {
                 "error": {
                     "code": "DEP003",
-                    "message": "urllib3 imported but it is a transitive dependency",
+                    "message": "'urllib3' imported but it is a transitive dependency",
                 },
                 "module": "urllib3",
                 "location": {
@@ -111,7 +111,7 @@ def test_cli_multiple_requirements_txt(requirements_txt_project_builder: ToolSpe
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -123,7 +123,7 @@ def test_cli_multiple_requirements_txt(requirements_txt_project_builder: ToolSpe
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -135,7 +135,7 @@ def test_cli_multiple_requirements_txt(requirements_txt_project_builder: ToolSpe
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "black imported but declared as a dev dependency",
+                    "message": "'black' imported but declared as a dev dependency",
                 },
                 "module": "black",
                 "location": {
@@ -147,7 +147,7 @@ def test_cli_multiple_requirements_txt(requirements_txt_project_builder: ToolSpe
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/functional/cli/test_cli_src_directory.py
+++ b/tests/functional/cli/test_cli_src_directory.py
@@ -21,7 +21,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "isort defined as a dependency but not used in the codebase",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
                 },
                 "module": "isort",
                 "location": {
@@ -33,7 +33,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "requests defined as a dependency but not used in the codebase",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
                 },
                 "module": "requests",
                 "location": {
@@ -45,7 +45,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "mypy defined as a dependency but not used in the codebase",
+                    "message": "'mypy' defined as a dependency but not used in the codebase",
                 },
                 "module": "mypy",
                 "location": {
@@ -57,7 +57,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP002",
-                    "message": "pytest defined as a dependency but not used in the codebase",
+                    "message": "'pytest' defined as a dependency but not used in the codebase",
                 },
                 "module": "pytest",
                 "location": {
@@ -69,7 +69,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "httpx imported but missing from the dependency definitions",
+                    "message": "'httpx' imported but missing from the dependency definitions",
                 },
                 "module": "httpx",
                 "location": {
@@ -81,7 +81,7 @@ def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder)
             {
                 "error": {
                     "code": "DEP001",
-                    "message": "white imported but missing from the dependency definitions",
+                    "message": "'white' imported but missing from the dependency definitions",
                 },
                 "module": "white",
                 "location": {

--- a/tests/unit/reporters/test_json_reporter.py
+++ b/tests/unit/reporters/test_json_reporter.py
@@ -35,7 +35,7 @@ def test_simple(tmp_path: Path) -> None:
 
         assert data == [
             {
-                "error": {"code": "DEP001", "message": "foo imported but missing from the dependency definitions"},
+                "error": {"code": "DEP001", "message": "'foo' imported but missing from the dependency definitions"},
                 "module": "foo",
                 "location": {
                     "file": str(Path("foo.py")),
@@ -44,7 +44,7 @@ def test_simple(tmp_path: Path) -> None:
                 },
             },
             {
-                "error": {"code": "DEP002", "message": "foo defined as a dependency but not used in the codebase"},
+                "error": {"code": "DEP002", "message": "'foo' defined as a dependency but not used in the codebase"},
                 "module": "foo",
                 "location": {
                     "file": str(Path("pyproject.toml")),
@@ -53,7 +53,7 @@ def test_simple(tmp_path: Path) -> None:
                 },
             },
             {
-                "error": {"code": "DEP003", "message": "foo_package imported but it is a transitive dependency"},
+                "error": {"code": "DEP003", "message": "'foo_package' imported but it is a transitive dependency"},
                 "module": "foo",
                 "location": {
                     "file": str(Path("foo/bar.py")),
@@ -62,7 +62,7 @@ def test_simple(tmp_path: Path) -> None:
                 },
             },
             {
-                "error": {"code": "DEP004", "message": "foo imported but declared as a dev dependency"},
+                "error": {"code": "DEP004", "message": "'foo' imported but declared as a dev dependency"},
                 "module": "foo",
                 "location": {
                     "file": str(Path("foo.py")),

--- a/tests/unit/reporters/test_text_reporter.py
+++ b/tests/unit/reporters/test_text_reporter.py
@@ -31,10 +31,10 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
 
     assert caplog.messages == [
         "",
-        f"{str(Path('foo.py'))}:1:2: DEP001 foo imported but missing from the dependency definitions",
-        f"{str(Path('pyproject.toml'))}: DEP002 foo defined as a dependency but not used in the codebase",
-        f"{str(Path('foo/bar.py'))}:1:2: DEP003 foo_package imported but it is a transitive dependency",
-        f"{str(Path('foo.py'))}:1:2: DEP004 foo imported but declared as a dev dependency",
+        f"{str(Path('foo.py'))}:1:2: DEP001 'foo' imported but missing from the dependency definitions",
+        f"{str(Path('pyproject.toml'))}: DEP002 'foo' defined as a dependency but not used in the codebase",
+        f"{str(Path('foo/bar.py'))}:1:2: DEP003 'foo_package' imported but it is a transitive dependency",
+        f"{str(Path('foo.py'))}:1:2: DEP004 'foo' imported but declared as a dev dependency",
         "Found 4 dependency issues.",
         "\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/",
     ]
@@ -48,7 +48,7 @@ def test_logging_number_single(caplog: LogCaptureFixture) -> None:
 
     assert caplog.messages == [
         "",
-        "foo.py:1:2: DEP001 foo imported but missing from the dependency definitions",
+        "foo.py:1:2: DEP001 'foo' imported but missing from the dependency definitions",
         "Found 1 dependency issue.",
         "\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/",
     ]

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -81,6 +81,7 @@ def test__get_local_modules(
             Core(
                 root=tmp_path / root_suffix,
                 config=Path("pyproject.toml"),
+                no_ansi=False,
                 ignore_obsolete=(),
                 ignore_missing=(),
                 ignore_transitive=(),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,6 +5,8 @@ import os
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Generator
 
+from deptry.reporters.text import COLORS
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -47,3 +49,7 @@ def create_files(paths: list[Path]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w"):
             pass
+
+
+def stylize(text: str, **kwargs: Any) -> str:
+    return text.format(**kwargs, **COLORS)


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

Follow up on https://github.com/fpgmaas/deptry/pull/357 to add colours to the terminal output, similarly to other tools like `flake8`, `ruff` or `mypy`.

A `--no-ansi` option is also added on the CLI to be able to disable this behaviour, for terminals that do not support ANSI characters, or if users want to opt-out from this.

On Windows, ANSI characters do not work out-of-the-box, so we leverage https://github.com/tartley/colorama to be able to display colours.