### PR TITLE
fix(python_file_finder): load gitignore from where CLI is invoked

### DIFF
--- a/deptry/python_file_finder.py
+++ b/deptry/python_file_finder.py
@@ -34,7 +34,7 @@ class PythonFileFinder:
         ignore_regex = re.compile("|".join(self.exclude + self.extend_exclude))
         file_lookup_suffixes = {".py"} if self.ignore_notebooks else {".py", ".ipynb"}
 
-        gitignore_spec = self._generate_gitignore_pathspec(directory)
+        gitignore_spec = self._generate_gitignore_pathspec(Path("."))
 
         for root_str, dirs, files in os.walk(directory, topdown=True):
             root = Path(root_str)

--- a/tests/data/project_with_src_directory/.gitignore
+++ b/tests/data/project_with_src_directory/.gitignore
@@ -1,0 +1,1 @@
+src/this_file_is_gitignored.py

--- a/tests/data/project_with_src_directory/src/this_file_is_gitignored.py
+++ b/tests/data/project_with_src_directory/src/this_file_is_gitignored.py
@@ -1,0 +1,1 @@
+import a_non_existing_module


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

`.gitignore` is currently looked for based on the root directory passed as a CLI argument. This means that developers using a `src` directory and invoking `deptry` with `deptry src` won't benefit from gitignore being loaded.

I don't think that there are a lot of use cases where `.gitignore` would be located in a different directory that the one `deptry` is launched from, so this PR updates the behaviour so that `.gitignore` is always loaded based on where `deptry` is invoked.

If there really is a need for explicitly configuring the path to `.gitignore`, we can think about adding an option later.

Note that this PR will also facilitate the implementation of https://github.com/fpgmaas/deptry/pull/381, even if doesn't strictly requires it, since we could also loop over each directory passed through the CLI.