### PR TITLE
fix(imports): handle `SyntaxError`

### DIFF
--- a/deptry/imports/extractors/notebook_import_extractor.py
+++ b/deptry/imports/extractors/notebook_import_extractor.py
@@ -36,7 +36,7 @@ class NotebookImportExtractor(ImportExtractor):
         try:
             with path_to_ipynb.open() as ipynb_file:
                 notebook: dict[str, Any] = json.load(ipynb_file)
-        except (UnicodeDecodeError, ValueError):
+        except ValueError:
             try:
                 with path_to_ipynb.open(encoding=cls._get_file_encoding(path_to_ipynb)) as ipynb_file:
                     notebook = json.load(ipynb_file, strict=False)

--- a/deptry/imports/extractors/python_import_extractor.py
+++ b/deptry/imports/extractors/python_import_extractor.py
@@ -20,7 +20,7 @@ class PythonImportExtractor(ImportExtractor):
         try:
             with self.file.open() as python_file:
                 tree = ast.parse(python_file.read(), str(self.file))
-        except (UnicodeDecodeError, ValueError):
+        except (SyntaxError, ValueError):
             try:
                 with self.file.open(encoding=self._get_file_encoding(self.file)) as python_file:
                     tree = ast.parse(python_file.read(), str(self.file))


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Since https://github.com/python/cpython/pull/97594, `ast.parse` can now raise `SyntaxError` while it would previously raise `ValueError`. This change was backported to 3.11.4, [breaking our current test suite](https://github.com/fpgmaas/deptry/actions/runs/5298012283/jobs/9590133734) on Windows for Python 3.11.

Also removing [`UnicodeDecodeError`](https://docs.python.org/3/library/exceptions.html#UnicodeDecodeError), because it's a subclass of [`UnicodeError`](https://docs.python.org/3/library/exceptions.html#UnicodeError), which is a subclass of [`ValueError`](https://docs.python.org/3/library/exceptions.html#ValueError), so it is redundant.