### PR TITLE
chore(pre-commit): use mirror for `black` to use `mypyc` wheels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     hooks:
       - id: ruff
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: "23.7.0"
     hooks:
       - id: black

--- a/renovate.json5
+++ b/renovate.json5
@@ -52,6 +52,10 @@
       matchPackageNames: ["astral-sh/ruff-pre-commit"],
       customChangelogUrl: "https://github.com/charliermarsh/ruff",
     },
+    {
+      matchPackageNames: ["psf/black-pre-commit-mirror"],
+      customChangelogUrl: "https://github.com/psf/black",
+    },
   ],
 
   // https://docs.renovatebot.com/configuration-options/#regexmanagers


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

[black](https://github.com/psf/black) releases [wheels compiled with `mypyc`](https://black.readthedocs.io/en/stable/contributing/release_process.html#mypyc-wheels), which are faster, but by using `pre-commit`, we are forced to build wheels, and they are not compiled with `mypyc`. [A mirror](https://github.com/psf/black-pre-commit-mirror) was [recently created](https://github.com/psf/black/issues/3405#issuecomment-1600079594) by one of `black`'s maintainers, which uses a similar technic as https://github.com/pre-commit/mirrors-mypy to use `mypyc`-compiled wheels, making `black` through `pre-commit` faster.