### PR TITLE
test(functional): use isolated virtual environments

### DIFF
--- a/deptry/__main__.py
+++ b/deptry/__main__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from deptry.cli import deptry
+
+deptry()

--- a/tests/functional/cli/test_cli_multiple_source_directories.py
+++ b/tests/functional/cli/test_cli_multiple_source_directories.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PipVenvFactory
 
 
-def test_cli_with_multiple_source_directories(pip_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(pip_project_builder("project_with_multiple_source_directories")):
-        result = CliRunner().invoke(deptry, "src worker -o report.json")
+def test_cli_with_multiple_source_directories(pip_venv_factory: PipVenvFactory) -> None:
+    with pip_venv_factory("project_with_multiple_source_directories") as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry src worker -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {"code": "DEP002", "message": "'toml' defined as a dependency but not used in the codebase"},
                 "module": "toml",

--- a/tests/functional/cli/test_cli_pdm.py
+++ b/tests/functional/cli/test_cli_pdm.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PDMVenvFactory
 
 
-def test_cli_with_pdm(pdm_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(pdm_project_builder("project_with_pdm")):
-        result = CliRunner().invoke(deptry, ". -o report.json")
+def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
+    with pdm_venv_factory("project_with_pdm") as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry . -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {
                     "code": "DEP002",

--- a/tests/functional/cli/test_cli_pep_621.py
+++ b/tests/functional/cli/test_cli_pep_621.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PipVenvFactory
 
 
-def test_cli_with_pep_621(pip_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(pip_project_builder("pep_621_project")):
-        result = CliRunner().invoke(deptry, ". -o report.json")
+def test_cli_with_pep_621(pip_venv_factory: PipVenvFactory) -> None:
+    with pip_venv_factory("pep_621_project") as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry . -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {
                     "code": "DEP002",

--- a/tests/functional/cli/test_cli_poetry.py
+++ b/tests/functional/cli/test_cli_poetry.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PoetryVenvFactory
 
 
-def test_cli_with_poetry(poetry_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(poetry_project_builder("project_with_poetry")):
-        result = CliRunner().invoke(deptry, ". -o report.json")
+def test_cli_with_poetry(poetry_venv_factory: PoetryVenvFactory) -> None:
+    with poetry_venv_factory("project_with_poetry") as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry . -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {
                     "code": "DEP002",

--- a/tests/functional/cli/test_cli_pyproject_different_directory.py
+++ b/tests/functional/cli/test_cli_pyproject_different_directory.py
@@ -1,23 +1,24 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PipVenvFactory
 
 
-def test_cli_with_pyproject_different_directory(pip_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(pip_project_builder("project_with_pyproject_different_directory", cwd="a_sub_directory")):
-        result = CliRunner().invoke(deptry, "src --config a_sub_directory/pyproject.toml -o report.json")
+def test_cli_with_pyproject_different_directory(pip_venv_factory: PipVenvFactory) -> None:
+    with pip_venv_factory(
+        "project_with_pyproject_different_directory", install_command="pip install ./a_sub_directory"
+    ) as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry src --config a_sub_directory/pyproject.toml -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {
                     "code": "DEP002",

--- a/tests/functional/cli/test_cli_src_directory.py
+++ b/tests/functional/cli/test_cli_src_directory.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from click.testing import CliRunner
-
-from deptry.cli import deptry
-from tests.utils import get_issues_report, run_within_dir
+from tests.utils import get_issues_report
 
 if TYPE_CHECKING:
-    from tests.functional.types import ToolSpecificProjectBuilder
+    from tests.utils import PipVenvFactory
 
 
-def test_cli_with_src_directory(pip_project_builder: ToolSpecificProjectBuilder) -> None:
-    with run_within_dir(pip_project_builder("project_with_src_directory")):
-        result = CliRunner().invoke(deptry, "src -o report.json")
+def test_cli_with_src_directory(pip_venv_factory: PipVenvFactory) -> None:
+    with pip_venv_factory("project_with_src_directory") as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(f"deptry src -o {issue_report}")
 
-        assert result.exit_code == 1
-        assert get_issues_report() == [
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {
                     "code": "DEP002",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,18 +1,8 @@
 from __future__ import annotations
 
-import shlex
-import shutil
-import subprocess
-import venv
-from pathlib import Path
-from typing import TYPE_CHECKING
-
 import pytest
 
-from tests.utils import PDMVenvFactory, PipVenvFactory, PoetryVenvFactory, run_within_dir
-
-if TYPE_CHECKING:
-    from tests.functional.types import ProjectBuilder, ToolSpecificProjectBuilder
+from tests.utils import PDMVenvFactory, PipVenvFactory, PoetryVenvFactory
 
 
 @pytest.fixture(scope="session")
@@ -28,78 +18,3 @@ def poetry_venv_factory(tmp_path_factory: pytest.TempPathFactory) -> PoetryVenvF
 @pytest.fixture(scope="session")
 def pip_venv_factory(tmp_path_factory: pytest.TempPathFactory) -> PipVenvFactory:
     return PipVenvFactory(tmp_path_factory.getbasetemp() / "venvs")
-
-
-def _build_project(root_directory: Path, project: str, setup_commands: list[str], cwd: str | None = None) -> Path:
-    project_path = root_directory / project
-
-    # If the fixture was already called with the same parameters, the project is already bootstrapped.
-    if project_path.exists():
-        return project_path / "project"
-
-    shutil.copytree(Path("tests/data") / project, project_path / "project")
-
-    env = venv.EnvBuilder(with_pip=True)
-    env.create(project_path)
-
-    deptry_directory = Path.cwd()
-
-    with run_within_dir(project_path / "project"):
-        for setup_command in [*setup_commands, f"pip install {deptry_directory}"]:
-            subprocess.check_call(
-                shlex.split(setup_command),
-                cwd=cwd,
-                env={"PATH": str(project_path / "bin"), "VIRTUAL_ENV": str(project_path)},
-            )
-
-    return project_path / "project"
-
-
-@pytest.fixture(scope="session")
-def project_builder() -> ProjectBuilder:
-    def _project_builder(root_directory: Path, project: str, setup_commands: list[str], cwd: str | None = None) -> Path:
-        return _build_project(root_directory, project, setup_commands, cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def poetry_project_builder() -> ToolSpecificProjectBuilder:
-    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
-        return _build_project(
-            root_directory, project, ["pip install poetry", "poetry install --no-interaction --no-root"], cwd
-        )
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def pip_project_builder() -> ToolSpecificProjectBuilder:
-    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
-        return _build_project(root_directory, project, ["pip install ."], cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def pdm_project_builder() -> ToolSpecificProjectBuilder:
-    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
-        return _build_project(root_directory, project, ["pip install pdm", "pdm install --no-self"], cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def requirements_txt_project_builder() -> ToolSpecificProjectBuilder:
-    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
-        return _build_project(
-            root_directory,
-            project,
-            [
-                "python -m pip install -r requirements.txt -r requirements-dev.txt -r requirements-2.txt -r"
-                " requirements-typing.txt"
-            ],
-            cwd,
-        )
-
-    return _project_builder

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -3,76 +3,102 @@ from __future__ import annotations
 import shlex
 import shutil
 import subprocess
+import venv
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
-from tests.utils import run_within_dir
+from tests.utils import PDMVenvFactory, PipVenvFactory, PoetryVenvFactory, run_within_dir
 
 if TYPE_CHECKING:
-    from _pytest.tmpdir import TempPathFactory
-
     from tests.functional.types import ProjectBuilder, ToolSpecificProjectBuilder
 
 
-def _build_project(root_directory: Path, project: str, setup_command: str, cwd: str | None = None) -> Path:
+@pytest.fixture(scope="session")
+def pdm_venv_factory(tmp_path_factory: pytest.TempPathFactory) -> PDMVenvFactory:
+    return PDMVenvFactory(tmp_path_factory.getbasetemp() / "venvs")
+
+
+@pytest.fixture(scope="session")
+def poetry_venv_factory(tmp_path_factory: pytest.TempPathFactory) -> PoetryVenvFactory:
+    return PoetryVenvFactory(tmp_path_factory.getbasetemp() / "venvs")
+
+
+@pytest.fixture(scope="session")
+def pip_venv_factory(tmp_path_factory: pytest.TempPathFactory) -> PipVenvFactory:
+    return PipVenvFactory(tmp_path_factory.getbasetemp() / "venvs")
+
+
+def _build_project(root_directory: Path, project: str, setup_commands: list[str], cwd: str | None = None) -> Path:
     project_path = root_directory / project
 
     # If the fixture was already called with the same parameters, the project is already bootstrapped.
     if project_path.exists():
-        return project_path
+        return project_path / "project"
 
-    shutil.copytree(Path("tests/data") / project, project_path)
+    shutil.copytree(Path("tests/data") / project, project_path / "project")
 
-    with run_within_dir(project_path):
-        assert subprocess.check_call(shlex.split(setup_command), cwd=cwd) == 0
+    env = venv.EnvBuilder(with_pip=True)
+    env.create(project_path)
 
-    return project_path
+    deptry_directory = Path.cwd()
+
+    with run_within_dir(project_path / "project"):
+        for setup_command in [*setup_commands, f"pip install {deptry_directory}"]:
+            subprocess.check_call(
+                shlex.split(setup_command),
+                cwd=cwd,
+                env={"PATH": str(project_path / "bin"), "VIRTUAL_ENV": str(project_path)},
+            )
+
+    return project_path / "project"
 
 
 @pytest.fixture(scope="session")
-def project_builder(tmp_path_factory: TempPathFactory) -> ProjectBuilder:
-    def _project_builder(project: str, setup_command: str, cwd: str | None = None) -> Path:
-        return _build_project(tmp_path_factory.getbasetemp(), project, setup_command, cwd)
+def project_builder() -> ProjectBuilder:
+    def _project_builder(root_directory: Path, project: str, setup_commands: list[str], cwd: str | None = None) -> Path:
+        return _build_project(root_directory, project, setup_commands, cwd)
 
     return _project_builder
 
 
 @pytest.fixture(scope="session")
-def poetry_project_builder(tmp_path_factory: TempPathFactory) -> ToolSpecificProjectBuilder:
-    def _project_builder(project: str, cwd: str | None = None) -> Path:
-        return _build_project(tmp_path_factory.getbasetemp(), project, "poetry install --no-interaction --no-root", cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def pip_project_builder(tmp_path_factory: TempPathFactory) -> ToolSpecificProjectBuilder:
-    def _project_builder(project: str, cwd: str | None = None) -> Path:
-        return _build_project(tmp_path_factory.getbasetemp(), project, "pip install .", cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def pdm_project_builder(tmp_path_factory: TempPathFactory) -> ToolSpecificProjectBuilder:
-    def _project_builder(project: str, cwd: str | None = None) -> Path:
-        return _build_project(tmp_path_factory.getbasetemp(), project, "pip install pdm; pdm install", cwd)
-
-    return _project_builder
-
-
-@pytest.fixture(scope="session")
-def requirements_txt_project_builder(tmp_path_factory: TempPathFactory) -> ToolSpecificProjectBuilder:
-    def _project_builder(project: str, cwd: str | None = None) -> Path:
+def poetry_project_builder() -> ToolSpecificProjectBuilder:
+    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
         return _build_project(
-            tmp_path_factory.getbasetemp(),
+            root_directory, project, ["pip install poetry", "poetry install --no-interaction --no-root"], cwd
+        )
+
+    return _project_builder
+
+
+@pytest.fixture(scope="session")
+def pip_project_builder() -> ToolSpecificProjectBuilder:
+    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
+        return _build_project(root_directory, project, ["pip install ."], cwd)
+
+    return _project_builder
+
+
+@pytest.fixture(scope="session")
+def pdm_project_builder() -> ToolSpecificProjectBuilder:
+    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
+        return _build_project(root_directory, project, ["pip install pdm", "pdm install --no-self"], cwd)
+
+    return _project_builder
+
+
+@pytest.fixture(scope="session")
+def requirements_txt_project_builder() -> ToolSpecificProjectBuilder:
+    def _project_builder(root_directory: Path, project: str, cwd: str | None = None) -> Path:
+        return _build_project(
+            root_directory,
             project,
-            (
+            [
                 "python -m pip install -r requirements.txt -r requirements-dev.txt -r requirements-2.txt -r"
                 " requirements-typing.txt"
-            ),
+            ],
             cwd,
         )
 

--- a/tests/functional/types.py
+++ b/tests/functional/types.py
@@ -7,10 +7,10 @@ if TYPE_CHECKING:
 
 
 class ProjectBuilder(Protocol):
-    def __call__(self, project: str, setup_command: str, cwd: str | None) -> Path:
+    def __call__(self, root_directory: Path, project: str, setup_commands: list[str], cwd: str | None) -> Path:
         ...
 
 
 class ToolSpecificProjectBuilder(Protocol):
-    def __call__(self, project: str, cwd: str | None = None) -> Path:
+    def __call__(self, root_directory: Path, project: str, cwd: str | None = None) -> Path:
         ...

--- a/tests/unit/reporters/test_text.py
+++ b/tests/unit/reporters/test_text.py
@@ -38,6 +38,10 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
         TextReporter(violations).report()
 
     assert caplog.messages == [
+        (
+            "Assuming the corresponding module name of package 'foo' is 'foo'. Install the package or configure a"
+            " package_module_name_map entry to override this behaviour."
+        ),
         "",
         stylize(
             (
@@ -117,6 +121,10 @@ def test_logging_no_ansi(caplog: LogCaptureFixture) -> None:
         TextReporter(violations, use_ansi=False).report()
 
     assert caplog.messages == [
+        (
+            "Assuming the corresponding module name of package 'foo' is 'foo'. Install the package or configure a"
+            " package_module_name_map entry to override this behaviour."
+        ),
         "",
         f"{Path('foo.py')}:1:2: DEP001 'foo' imported but missing from the dependency definitions",
         f"{Path('pyproject.toml')}: DEP002 'foo' defined as a dependency but not used in the codebase",

--- a/tests/unit/violations/dep002_unused/test_finder.py
+++ b/tests/unit/violations/dep002_unused/test_finder.py
@@ -38,7 +38,7 @@ def test_top_level() -> None:
     Test if top-level information is read, and correctly used to not mark a dependency as unused.
     blackd is in the top-level of black, so black should not be marked as an unused dependency.
     """
-    dependencies = [Dependency("black", Path("pyproject.toml"))]
+    dependencies = [Dependency("black", Path("pyproject.toml"), module_names=("black", "blackd"))]
     modules_locations = [
         ModuleLocations(
             ModuleBuilder("blackd", {"foo"}, frozenset(), dependencies).build(), [Location(Path("foo.py"), 1, 2)]


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Functional tests currently run in the same virtual environment as the one running the tests, meaning that dependencies dependencies installations of each functional test are actually shared with the main virtual environment.

This causes issues at multiple levels:
- Functional tests outputs are less predictable
- Unit tests outputs, as well as CI workflows (see https://github.com/fpgmaas/deptry/pull/439#issuecomment-1627094658), are affected by dependencies installations from functional tests

This PR introduces isolated virtual environments for functional tests, to ensure that each project we use in functional tests have their own virtual environment. In order to not increase too much the time it takes to run functional tests, virtual environments are re-used for each project, so for instance, if 2 tests depend on `example_project`, we will only setup the virtual environment once, then re-use it for the 2nd test.

This PR also:
- Fixes some unit tests outputs, that were only passing because the functional tests were affecting the environment
- Adds a `__main__.py` entry point, allowing invocations of `deptry` through `python -m deptry` (this is a similar fix as https://github.com/psf/black/pull/1460)