### PR TITLE
chore: replace `black` with `ruff format`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,5 @@ repos:
     rev: "v0.1.3"
     hooks:
       - id: ruff
-
-  - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: "23.9.1"
-    hooks:
-      - id: black
+        args: [--exit-non-zero-on-fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,6 @@ types-colorama = { version = "0.4.15.12", markers = "sys_platform == 'win32'" }
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.black]
-line-length = 120
-target-version = ["py38"]
-preview = true
-
 [tool.coverage.report]
 skip_empty = true
 # Subset of rules from https://pypi.org/project/covdefaults/
@@ -172,6 +167,9 @@ extend-exclude = ["tests/data/*"]
 
 [tool.ruff.flake8-type-checking]
 strict = true
+
+[tool.ruff.format]
+preview = true
 
 [tool.ruff.isort]
 required-imports = ["from __future__ import annotations"]

--- a/renovate.json5
+++ b/renovate.json5
@@ -52,10 +52,6 @@
       matchPackageNames: ["astral-sh/ruff-pre-commit"],
       customChangelogUrl: "https://github.com/charliermarsh/ruff",
     },
-    {
-      matchPackageNames: ["psf/black-pre-commit-mirror"],
-      customChangelogUrl: "https://github.com/psf/black",
-    },
   ],
 
   // https://docs.renovatebot.com/configuration-options/#regexmanagers

--- a/tests/unit/deprecate/test_ignore_flags.py
+++ b/tests/unit/deprecate/test_ignore_flags.py
@@ -13,8 +13,7 @@ if TYPE_CHECKING:
 def test_generate_deprecation_warning() -> None:
     result = generate_deprecation_warning(flag_name="ignore-missing", issue_code="DEP002", sequence=("hi", "bye"))
     assert (
-        result
-        == "Warning: In an upcoming release, support for the `--ignore-missing` command-line option and the"
+        result == "Warning: In an upcoming release, support for the `--ignore-missing` command-line option and the"
         " `ignore_missing` configuration parameter will be discontinued. Instead, use `--per-rule-ignores"
         ' DEP002=hi|bye` or add a line `DEP002 = ["hi", "bye"]` to the `[tool.deptry.per_rule_ignores]` section of the'
         " configuration file."


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Replace Black with [Ruff format](https://astral.sh/blog/the-ruff-formatter). Black preview style is not fully supported yet (https://github.com/astral-sh/ruff/issues/6935), but given the small size of our codebase, this should not be too much of a problem, and full support for it is likely to be fully implemented rather quickly.