### PR TITLE
fix(dependency_getter): stricten URL guessing

### DIFF
--- a/deptry/dependency_getter/requirements_txt.py
+++ b/deptry/dependency_getter/requirements_txt.py
@@ -6,7 +6,7 @@ import os
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Match
+from urllib.parse import urlparse
 
 from deptry.dependency import Dependency
 from deptry.dependency_getter.base import DependenciesExtract, DependencyGetter
@@ -114,8 +114,8 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
         return ";" in line
 
     @staticmethod
-    def _line_is_url(line: str) -> Match[str] | None:
-        return re.search(r"^(http|https|git\+https)", line)
+    def _line_is_url(line: str) -> bool:
+        return urlparse(line).scheme != ""
 
     @staticmethod
     def _extract_name_from_url(line: str) -> str | None:


### PR DESCRIPTION
Resolves #539.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] [not applicable] ~Documentation in `docs` is updated~

**Description of changes**

This strictens URL guessing when parsing `requirements.txt` format files by using `urllib.parse.urlparse`. At some point it would be nice to leverage parsing of dependencies to https://pypi.org/project/packaging/, although the library does not support legacy URL formats that AFAIK are still supported by `pip`, despite not being recommended anymore. I have a draft PR for this in https://github.com/mkniewallner/deptry/pull/29 that I should someday finish.