### PR TITLE
feat(config): detect invalid `pyproject.toml` options

### DIFF
--- a/deptry/config.py
+++ b/deptry/config.py
@@ -3,12 +3,20 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from deptry.exceptions import InvalidPyprojectTOMLOptionsError
 from deptry.utils import load_pyproject_toml
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     import click
+
+
+def _get_invalid_pyproject_toml_keys(ctx: click.Context, deptry_toml_config_keys: set[str]) -> list[str]:
+    """Returns the list of options set in `pyproject.toml` that do not exist as CLI parameters."""
+    existing_cli_params = {param.name for param in ctx.command.params}
+
+    return sorted(deptry_toml_config_keys.difference(existing_cli_params))
 
 
 def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Parameter, value: Path) -> Path | None:
@@ -28,10 +36,14 @@ def read_configuration_from_pyproject_toml(ctx: click.Context, _param: click.Par
         return value
 
     try:
-        deptry_toml_config = pyproject_data["tool"]["deptry"]
+        deptry_toml_config: dict[str, Any] = pyproject_data["tool"]["deptry"]
     except KeyError:
         logging.debug("No configuration for deptry was found in pyproject.toml.")
         return value
+
+    invalid_pyproject_toml_keys = _get_invalid_pyproject_toml_keys(ctx, set(deptry_toml_config))
+    if invalid_pyproject_toml_keys:
+        raise InvalidPyprojectTOMLOptionsError(invalid_pyproject_toml_keys)
 
     click_default_map: dict[str, Any] = {}
 

--- a/deptry/exceptions.py
+++ b/deptry/exceptions.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from click import UsageError
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -28,4 +30,11 @@ class UnsupportedPythonVersionError(ValueError):
     def __init__(self, version: tuple[int, int]) -> None:
         super().__init__(
             f"Python version {version[0]}.{version[1]} is not supported. Only versions >= 3.8 are supported."
+        )
+
+
+class InvalidPyprojectTOMLOptionsError(UsageError):
+    def __init__(self, invalid_options: list[str]) -> None:
+        super().__init__(
+            f"'[tool.deptry]' section in 'pyproject.toml' contains invalid configuration options: {invalid_options}."
         )


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Detect invalid configuration options set in `[tool.deptry]` section of `pyproject.toml` based on the list of existing arguments in the CLI. This will facilitate the removal of deprecated options, since currently, invalid options do not throw any runtime error, so if we end up removing options we have deprecated, the now gone options would just be ignored instead of throwing an error.