### PR TITLE
chore(cargo): aim for faster runtime on `release` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,8 @@ rayon = "1.9.0"
 regex = "1.10.3"
 rustpython-ast = { version = "0.3.0", features = ["visitor"] }
 rustpython-parser = "0.3.0"
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Per https://nnethercote.github.io/perf-book/build-configuration.html, there are a few optimisations we could apply to the artifacts we build when releasing.

Testing locally on macOS ARM, this lead to:
- ~5% runtime performance improvements when running `deptry` on a repository with ~7k files (from ~1.02s to ~970ms)
- ~20% reduction on the binary size (from 2.0M to 1.6M)

The tradeoff being that we will have longer compilation times, but since this should only impact the "release" profile and not the dev one, and we do not create releases that often, I think this should be an ok tradeoff.