### PR TITLE
chore(packaging): set license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "click>=8.0.0,<9",


### PR DESCRIPTION
Resolves #623.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

We've lost license classifier when switching from Poetry to PDM. Poetry [sets that automatically](https://python-poetry.org/docs/pyproject#classifiers), but PDM does not.