### PR TITLE
[1.4] chore(packaging): set license classifier (#624)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
+    "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
     "chardet>=4.0.0",


### PR DESCRIPTION
Backport of #623 to 1.4.x. Will tag a 0.14.2 right after.