### PR TITLE
Move docs to deptry.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependency issues are detected by scanning for imported modules within all Pytho
 
 ---
 <p align="center">
-  <a href="https://deptry.com/deptry">Documentation</a> - <a href="https://deptry.com/deptry/contributing/">Contributing</a>
+  <a href="https://deptry.com">Documentation</a> - <a href="https://deptry.com/contributing/">Contributing</a>
 </p>
 
 ---
@@ -66,7 +66,7 @@ Found 3 dependency issues.
 
 ### Configuration
 
-_deptry_ can be configured by using additional command line arguments, or by adding a `[tool.deptry]` section in _pyproject.toml_. For more information, see the [Usage and Configuration](https://deptry.com/deptry/usage/) section of the documentation..
+_deptry_ can be configured by using additional command line arguments, or by adding a `[tool.deptry]` section in _pyproject.toml_. For more information, see the [Usage and Configuration](https://deptry.com/usage/) section of the documentation..
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependency issues are detected by scanning for imported modules within all Pytho
 
 ---
 <p align="center">
-  <a href="https://fpgmaas.github.io/deptry">Documentation</a> - <a href="https://fpgmaas.github.io/deptry/contributing/">Contributing</a>
+  <a href="https://deptry.com/deptry">Documentation</a> - <a href="https://deptry.com/deptry/contributing/">Contributing</a>
 </p>
 
 ---
@@ -66,7 +66,7 @@ Found 3 dependency issues.
 
 ### Configuration
 
-_deptry_ can be configured by using additional command line arguments, or by adding a `[tool.deptry]` section in _pyproject.toml_. For more information, see the [Usage and Configuration](https://fpgmaas.github.io/deptry/usage/) section of the documentation..
+_deptry_ can be configured by using additional command line arguments, or by adding a `[tool.deptry]` section in _pyproject.toml_. For more information, see the [Usage and Configuration](https://deptry.com/deptry/usage/) section of the documentation..
 
 ---
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+deptry.com

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: deptry
 edit_uri: edit/main/docs/
 repo_name: fpgmaas/deptry
 repo_url: https://github.com/fpgmaas/deptry
-site_url: https://deptry.com/deptry
+site_url: https://deptry.com
 site_description: A command line tool to check for unused dependencies in a poetry managed python project.
 site_author: Florian Maas
 copyright: Maintained by <a href="https://fpgmaas.com">Florian</a>.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: deptry
 edit_uri: edit/main/docs/
 repo_name: fpgmaas/deptry
 repo_url: https://github.com/fpgmaas/deptry
-site_url: https://fpgmaas.github.io/deptry
+site_url: https://deptry.com/deptry
 site_description: A command line tool to check for unused dependencies in a poetry managed python project.
 site_author: Florian Maas
 copyright: Maintained by <a href="https://fpgmaas.com">Florian</a>.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ typing = [
 ]
 
 [project.urls]
-homepage = "https://deptry.com/deptry"
+homepage = "https://deptry.com"
 repository = "https://github.com/fpgmaas/deptry"
-documentation = "https://deptry.com/deptry"
+documentation = "https://deptry.com"
 changelog = "https://github.com/fpgmaas/deptry/blob/main/CHANGELOG.md"
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,9 @@ typing = [
 ]
 
 [project.urls]
-homepage = "https://fpgmaas.github.io/deptry"
+homepage = "https://deptry.com/deptry"
 repository = "https://github.com/fpgmaas/deptry"
-documentation = "https://fpgmaas.github.io/deptry"
+documentation = "https://deptry.com/deptry"
 changelog = "https://github.com/fpgmaas/deptry/blob/main/CHANGELOG.md"
 
 [project.scripts]

--- a/python/deptry/cli.py
+++ b/python/deptry/cli.py
@@ -135,7 +135,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     "-i",
     type=COMMA_SEPARATED_TUPLE,
     help="""A comma-separated list of error codes to ignore. e.g. `deptry --ignore DEP001,DEP002`
-    For more information regarding the error codes, see https://fpgmaas.github.io/deptry/issue-codes/""",
+    For more information regarding the error codes, see https://deptry.com/deptry/issue-codes/""",
     default=(),
 )
 @click.option(
@@ -144,7 +144,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     type=COMMA_SEPARATED_MAPPING,
     help="""A comma-separated mapping of packages or modules to be ignored per error code.
     . e.g. ``deptry . --per-rule-ignores DEP001=matplotlib,DEP002=pandas|numpy``
-    For more information regarding the error codes, see https://fpgmaas.github.io/deptry/issue-codes/""",
+    For more information regarding the error codes, see https://deptry.com/deptry/issue-codes/""",
     default={},
 )
 @click.option(

--- a/python/deptry/cli.py
+++ b/python/deptry/cli.py
@@ -135,7 +135,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     "-i",
     type=COMMA_SEPARATED_TUPLE,
     help="""A comma-separated list of error codes to ignore. e.g. `deptry --ignore DEP001,DEP002`
-    For more information regarding the error codes, see https://deptry.com/deptry/issue-codes/""",
+    For more information regarding the error codes, see https://deptry.com/issue-codes/""",
     default=(),
 )
 @click.option(
@@ -144,7 +144,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     type=COMMA_SEPARATED_MAPPING,
     help="""A comma-separated mapping of packages or modules to be ignored per error code.
     . e.g. ``deptry . --per-rule-ignores DEP001=matplotlib,DEP002=pandas|numpy``
-    For more information regarding the error codes, see https://deptry.com/deptry/issue-codes/""",
+    For more information regarding the error codes, see https://deptry.com/issue-codes/""",
     default={},
 )
 @click.option(

--- a/python/deptry/reporters/text.py
+++ b/python/deptry/reporters/text.py
@@ -42,7 +42,7 @@ class TextReporter(Reporter):
                     issue_word="issues" if len(violations) > 1 else "issue",
                 )
             )
-            logging.info("\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/")
+            logging.info("\nFor more information, see the documentation: https://deptry.com/deptry/")
         else:
             logging.info(self._stylize("{BOLD}{GREEN}Success! No dependency issues found.{RESET}"))
 

--- a/python/deptry/reporters/text.py
+++ b/python/deptry/reporters/text.py
@@ -42,7 +42,7 @@ class TextReporter(Reporter):
                     issue_word="issues" if len(violations) > 1 else "issue",
                 )
             )
-            logging.info("\nFor more information, see the documentation: https://deptry.com/deptry/")
+            logging.info("\nFor more information, see the documentation: https://deptry.com/")
         else:
             logging.info(self._stylize("{BOLD}{GREEN}Success! No dependency issues found.{RESET}"))
 

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -484,7 +484,7 @@ def test_cli_with_no_ansi(poetry_venv_factory: PoetryVenvFactory) -> None:
             f"{Path('src/main.py')}:6:8: DEP001 'white' imported but missing from the dependency definitions",
             "Found 4 dependency issues.",
             "",
-            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "For more information, see the documentation: https://deptry.com/deptry/",
             "",
         ]
 
@@ -524,7 +524,7 @@ def test_cli_with_not_json_output(poetry_venv_factory: PoetryVenvFactory) -> Non
             ),
             stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
             "",
-            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "For more information, see the documentation: https://deptry.com/deptry/",
             "",
         ]
 
@@ -565,7 +565,7 @@ def test_cli_with_json_output(poetry_venv_factory: PoetryVenvFactory) -> None:
             ),
             stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
             "",
-            "For more information, see the documentation: https://fpgmaas.github.io/deptry/",
+            "For more information, see the documentation: https://deptry.com/deptry/",
             "",
         ]
 

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -484,7 +484,7 @@ def test_cli_with_no_ansi(poetry_venv_factory: PoetryVenvFactory) -> None:
             f"{Path('src/main.py')}:6:8: DEP001 'white' imported but missing from the dependency definitions",
             "Found 4 dependency issues.",
             "",
-            "For more information, see the documentation: https://deptry.com/deptry/",
+            "For more information, see the documentation: https://deptry.com/",
             "",
         ]
 
@@ -524,7 +524,7 @@ def test_cli_with_not_json_output(poetry_venv_factory: PoetryVenvFactory) -> Non
             ),
             stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
             "",
-            "For more information, see the documentation: https://deptry.com/deptry/",
+            "For more information, see the documentation: https://deptry.com/",
             "",
         ]
 
@@ -565,7 +565,7 @@ def test_cli_with_json_output(poetry_venv_factory: PoetryVenvFactory) -> None:
             ),
             stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
             "",
-            "For more information, see the documentation: https://deptry.com/deptry/",
+            "For more information, see the documentation: https://deptry.com/",
             "",
         ]
 

--- a/tests/unit/reporters/test_text.py
+++ b/tests/unit/reporters/test_text.py
@@ -64,7 +64,7 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
             file=Path("foo.py"),
         ),
         stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
-        "\nFor more information, see the documentation: https://deptry.com/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/",
     ]
 
 
@@ -82,7 +82,7 @@ def test_logging_number_single(caplog: LogCaptureFixture) -> None:
             file=Path("foo.py"),
         ),
         stylize("{BOLD}{RED}Found 1 dependency issue.{RESET}"),
-        "\nFor more information, see the documentation: https://deptry.com/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/",
     ]
 
 
@@ -121,7 +121,7 @@ def test_logging_no_ansi(caplog: LogCaptureFixture) -> None:
         f"{Path('foo/bar.py')}:1:2: DEP003 'foo_package' imported but it is a transitive dependency",
         f"{Path('foo.py')}:1:2: DEP004 'foo' imported but declared as a dev dependency",
         "Found 4 dependency issues.",
-        "\nFor more information, see the documentation: https://deptry.com/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/",
     ]
 
 

--- a/tests/unit/reporters/test_text.py
+++ b/tests/unit/reporters/test_text.py
@@ -64,7 +64,7 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
             file=Path("foo.py"),
         ),
         stylize("{BOLD}{RED}Found 4 dependency issues.{RESET}"),
-        "\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/deptry/",
     ]
 
 
@@ -82,7 +82,7 @@ def test_logging_number_single(caplog: LogCaptureFixture) -> None:
             file=Path("foo.py"),
         ),
         stylize("{BOLD}{RED}Found 1 dependency issue.{RESET}"),
-        "\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/deptry/",
     ]
 
 
@@ -121,7 +121,7 @@ def test_logging_no_ansi(caplog: LogCaptureFixture) -> None:
         f"{Path('foo/bar.py')}:1:2: DEP003 'foo_package' imported but it is a transitive dependency",
         f"{Path('foo.py')}:1:2: DEP004 'foo' imported but declared as a dev dependency",
         "Found 4 dependency issues.",
-        "\nFor more information, see the documentation: https://fpgmaas.github.io/deptry/",
+        "\nFor more information, see the documentation: https://deptry.com/deptry/",
     ]
 
 


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [x] Documentation in `docs` is updated

**Description of changes**

I propose we migrate the documentation to `deptry.com`. By changing the repository settings, Github created [this commit](https://github.com/fpgmaas/deptry/commits/gh-pages/). This will be overwritten the next time we deploy the documentation, so we need to add the `CNAME` file to the `docs` directory. In addition, I updated the URL's in various locations in the repo.