### PR TITLE
feat(pdm): handle PEP 621 dev groups

### DIFF
--- a/python/deptry/core.py
+++ b/python/deptry/core.py
@@ -63,6 +63,8 @@ class Core:
         ).detect()
         dependencies_extract = self._get_dependencies(dependency_management_format)
 
+        self._log_dependencies(dependencies_extract)
+
         all_python_files = PythonFileFinder(
             self.exclude, self.extend_exclude, self.using_default_exclude, self.ignore_notebooks
         ).get_all_python_files_in(self.root)
@@ -190,6 +192,20 @@ class Core:
         for key, value in vars(self).items():
             logging.debug("%s: %s", key, value)
         logging.debug("")
+
+    @staticmethod
+    def _log_dependencies(dependencies_extract: DependenciesExtract) -> None:
+        if dependencies_extract.dependencies:
+            logging.debug("The project contains the following dependencies:")
+            for dependency in dependencies_extract.dependencies:
+                logging.debug(dependency)
+            logging.debug("")
+
+        if dependencies_extract.dev_dependencies:
+            logging.debug("The project contains the following dev dependencies:")
+            for dependency in dependencies_extract.dev_dependencies:
+                logging.debug(dependency)
+            logging.debug("")
 
     @staticmethod
     def _exit(violations: list[Violation]) -> None:

--- a/python/deptry/core.py
+++ b/python/deptry/core.py
@@ -144,7 +144,9 @@ class Core:
         if dependency_management_format is DependencyManagementFormat.POETRY:
             return PoetryDependencyGetter(self.config, self.package_module_name_map).get()
         if dependency_management_format is DependencyManagementFormat.PDM:
-            return PDMDependencyGetter(self.config, self.package_module_name_map).get()
+            return PDMDependencyGetter(
+                self.config, self.package_module_name_map, self.pep621_dev_dependency_groups
+            ).get()
         if dependency_management_format is DependencyManagementFormat.PEP_621:
             return PEP621DependencyGetter(
                 self.config, self.package_module_name_map, self.pep621_dev_dependency_groups

--- a/python/deptry/dependency_getter/base.py
+++ b/python/deptry/dependency_getter/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -36,12 +35,3 @@ class DependencyGetter(ABC):
     def get(self) -> DependenciesExtract:
         """Get extracted dependencies and dev dependencies."""
         raise NotImplementedError()
-
-    @staticmethod
-    def _log_dependencies(dependencies: list[Dependency], is_dev: bool = False) -> None:
-        logging.debug("The project contains the following %s:", "dev dependencies" if is_dev else "dependencies")
-
-        for dependency in dependencies:
-            logging.debug(dependency)
-
-        logging.debug("")

--- a/python/deptry/dependency_getter/pdm.py
+++ b/python/deptry/dependency_getter/pdm.py
@@ -21,7 +21,10 @@ class PDMDependencyGetter(PEP621DependencyGetter):
     def get(self) -> DependenciesExtract:
         pep_621_dependencies_extract = super().get()
 
-        return DependenciesExtract(pep_621_dependencies_extract.dependencies, self._get_pdm_dev_dependencies())
+        return DependenciesExtract(
+            pep_621_dependencies_extract.dependencies,
+            [*pep_621_dependencies_extract.dev_dependencies, *self._get_pdm_dev_dependencies()],
+        )
 
     def _get_pdm_dev_dependencies(self) -> list[Dependency]:
         """

--- a/python/deptry/dependency_getter/pdm.py
+++ b/python/deptry/dependency_getter/pdm.py
@@ -21,10 +21,7 @@ class PDMDependencyGetter(PEP621DependencyGetter):
     def get(self) -> DependenciesExtract:
         pep_621_dependencies_extract = super().get()
 
-        dev_dependencies = self._get_pdm_dev_dependencies()
-        self._log_dependencies(dev_dependencies, is_dev=True)
-
-        return DependenciesExtract(pep_621_dependencies_extract.dependencies, dev_dependencies)
+        return DependenciesExtract(pep_621_dependencies_extract.dependencies, self._get_pdm_dev_dependencies())
 
     def _get_pdm_dev_dependencies(self) -> list[Dependency]:
         """

--- a/python/deptry/dependency_getter/pep_621.py
+++ b/python/deptry/dependency_getter/pep_621.py
@@ -51,12 +51,9 @@ class PEP621DependencyGetter(DependencyGetter):
                 self._split_development_dependencies_from_optional_dependencies(optional_dependencies)
             )
             dependencies = [*dependencies, *leftover_optional_dependencies]
-            self._log_dependencies(dependencies)
-            self._log_dependencies(dev_dependencies, is_dev=True)
             return DependenciesExtract(dependencies, dev_dependencies)
 
         dependencies = [*dependencies, *itertools.chain(*optional_dependencies.values())]
-        self._log_dependencies(dependencies)
         return DependenciesExtract(dependencies, [])
 
     def _get_dependencies(self) -> list[Dependency]:

--- a/python/deptry/dependency_getter/poetry.py
+++ b/python/deptry/dependency_getter/poetry.py
@@ -17,13 +17,7 @@ class PoetryDependencyGetter(DependencyGetter):
     """Extract Poetry dependencies from pyproject.toml."""
 
     def get(self) -> DependenciesExtract:
-        dependencies = self._get_poetry_dependencies()
-        self._log_dependencies(dependencies)
-
-        dev_dependencies = self._get_poetry_dev_dependencies()
-        self._log_dependencies(dev_dependencies, is_dev=True)
-
-        return DependenciesExtract(dependencies, dev_dependencies)
+        return DependenciesExtract(self._get_poetry_dependencies(), self._get_poetry_dev_dependencies())
 
     def _get_poetry_dependencies(self) -> list[Dependency]:
         pyproject_data = load_pyproject_toml(self.config)

--- a/python/deptry/dependency_getter/requirements_txt.py
+++ b/python/deptry/dependency_getter/requirements_txt.py
@@ -25,7 +25,6 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
                 *(self._get_dependencies_from_requirements_file(file_name) for file_name in self.requirements_txt)
             )
         )
-        self._log_dependencies(dependencies=dependencies)
 
         dev_dependencies = list(
             itertools.chain(
@@ -35,7 +34,6 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
                 )
             )
         )
-        self._log_dependencies(dependencies=dev_dependencies, is_dev=True)
 
         return DependenciesExtract(dependencies, dev_dependencies)
 

--- a/tests/data/project_with_pdm/pyproject.toml
+++ b/tests/data/project_with_pdm/pyproject.toml
@@ -28,5 +28,8 @@ test = [
     "pytest-cov>=4.0.0",
 ]
 
+[tool.deptry]
+pep621_dev_dependency_groups = ["bar"]
+
 [tool.deptry.per_rule_ignores]
 DEP002 = ["pkginfo"]

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -418,6 +418,7 @@ def test_cli_verbose(poetry_venv_factory: PoetryVenvFactory) -> None:
 
         assert result.returncode == 1
         assert "The project contains the following dependencies:" in result.stderr
+        assert "The project contains the following dev dependencies:" in result.stderr
         assert get_issues_report(Path(issue_report)) == [
             {
                 "error": {

--- a/tests/functional/cli/test_cli_pdm.py
+++ b/tests/functional/cli/test_cli_pdm.py
@@ -35,18 +35,6 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
             },
             {
                 "error": {
-                    "code": "DEP002",
-                    "message": "'requests' defined as a dependency but not used in the codebase",
-                },
-                "module": "requests",
-                "location": {
-                    "file": str(Path("pyproject.toml")),
-                    "line": None,
-                    "column": None,
-                },
-            },
-            {
-                "error": {
                     "code": "DEP004",
                     "message": "'black' imported but declared as a dev dependency",
                 },

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import re
 import sys
 from pathlib import Path
@@ -9,6 +10,7 @@ import pytest
 
 from deptry.core import Core
 from deptry.dependency import Dependency
+from deptry.dependency_getter.base import DependenciesExtract
 from deptry.exceptions import UnsupportedPythonVersionError
 from deptry.imports.location import Location
 from deptry.module import Module
@@ -167,3 +169,45 @@ def test__exit_without_violations() -> None:
 
     assert e.type == SystemExit
     assert e.value.code == 0
+
+
+@pytest.mark.parametrize(
+    ("dependencies", "dev_dependencies", "expected_logs"),
+    [
+        (
+            [],
+            [],
+            [],
+        ),
+        (
+            [
+                Dependency("foo", Path("pyproject.toml")),
+                Dependency("bar", Path("pyproject.toml")),
+            ],
+            [
+                Dependency("dev", Path("pyproject.toml")),
+                Dependency("another-dev", Path("pyproject.toml")),
+            ],
+            [
+                "The project contains the following dependencies:",
+                "Dependency 'foo' with top-levels: {'foo'}.",
+                "Dependency 'bar' with top-levels: {'bar'}.",
+                "",
+                "The project contains the following dev dependencies:",
+                "Dependency 'dev' with top-levels: {'dev'}.",
+                "Dependency 'another-dev' with top-levels: {'another_dev'}.",
+                "",
+            ],
+        ),
+    ],
+)
+def test__log_dependencies(
+    dependencies: list[Dependency],
+    dev_dependencies: list[Dependency],
+    expected_logs: list[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.DEBUG):
+        Core._log_dependencies(DependenciesExtract(dependencies, dev_dependencies))
+
+    assert caplog.messages == expected_logs


### PR DESCRIPTION
Since PDM is based on PEP 621, we should probably also handle the new option added in https://github.com/fpgmaas/deptry/pull/628.

This also fixes the logging by moving the logic to `core`, otherwise we would log dev depencencies twice for PDM (once in `PEP621DependencyGetter` and once in `PDMDependencyGetter`.