### PR TITLE
fix(violations): show module name for DEP003

### DIFF
--- a/python/deptry/violations/dep003_transitive/violation.py
+++ b/python/deptry/violations/dep003_transitive/violation.py
@@ -16,4 +16,4 @@ class DEP003TransitiveDependencyViolation(Violation):
     issue: Module
 
     def get_error_message(self) -> str:
-        return self.error_template.format(name=self.issue.package)
+        return self.error_template.format(name=self.issue.name)

--- a/tests/unit/reporters/test_json.py
+++ b/tests/unit/reporters/test_json.py
@@ -20,15 +20,15 @@ def test_simple(tmp_path: Path) -> None:
     with run_within_dir(tmp_path):
         JSONReporter(
             [
-                DEP001MissingDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)),
+                DEP001MissingDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)),
                 DEP002UnusedDependencyViolation(
                     Dependency("foo", Path("pyproject.toml")), Location(Path("pyproject.toml"))
                 ),
                 DEP003TransitiveDependencyViolation(
-                    Module("foo", package="foo_package"), Location(Path("foo/bar.py"), 1, 2)
+                    Module("foo", package="foo-package"), Location(Path("foo/bar.py"), 1, 2)
                 ),
                 DEP004MisplacedDevDependencyViolation(
-                    Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)
+                    Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)
                 ),
             ],
             "output.json",
@@ -57,7 +57,7 @@ def test_simple(tmp_path: Path) -> None:
                 },
             },
             {
-                "error": {"code": "DEP003", "message": "'foo_package' imported but it is a transitive dependency"},
+                "error": {"code": "DEP003", "message": "'foo' imported but it is a transitive dependency"},
                 "module": "foo",
                 "location": {
                     "file": str(Path("foo/bar.py")),

--- a/tests/unit/reporters/test_text.py
+++ b/tests/unit/reporters/test_text.py
@@ -26,14 +26,14 @@ if TYPE_CHECKING:
 def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
     with caplog.at_level(logging.INFO):
         violations = [
-            DEP001MissingDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)),
+            DEP001MissingDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)),
             DEP002UnusedDependencyViolation(
                 Dependency("foo", Path("pyproject.toml")), Location(Path("pyproject.toml"))
             ),
             DEP003TransitiveDependencyViolation(
-                Module("foo", package="foo_package"), Location(Path("foo/bar.py"), 1, 2)
+                Module("foo", package="foo-package"), Location(Path("foo/bar.py"), 1, 2)
             ),
-            DEP004MisplacedDevDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)),
+            DEP004MisplacedDevDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)),
         ]
         TextReporter(violations).report()
 
@@ -54,7 +54,7 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
             file=Path("pyproject.toml"),
         ),
         stylize(
-            "{BOLD}{file}{RESET}{CYAN}:{RESET}1{CYAN}:{RESET}2{CYAN}:{RESET} {BOLD}{RED}DEP003{RESET} 'foo_package'"
+            "{BOLD}{file}{RESET}{CYAN}:{RESET}1{CYAN}:{RESET}2{CYAN}:{RESET} {BOLD}{RED}DEP003{RESET} 'foo'"
             " imported but it is a transitive dependency",
             file=Path("foo/bar.py"),
         ),
@@ -71,7 +71,7 @@ def test_logging_number_multiple(caplog: LogCaptureFixture) -> None:
 def test_logging_number_single(caplog: LogCaptureFixture) -> None:
     with caplog.at_level(logging.INFO):
         TextReporter([
-            DEP001MissingDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2))
+            DEP001MissingDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2))
         ]).report()
 
     assert caplog.messages == [
@@ -99,14 +99,14 @@ def test_logging_number_none(caplog: LogCaptureFixture) -> None:
 def test_logging_no_ansi(caplog: LogCaptureFixture) -> None:
     with caplog.at_level(logging.INFO):
         violations = [
-            DEP001MissingDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)),
+            DEP001MissingDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)),
             DEP002UnusedDependencyViolation(
                 Dependency("foo", Path("pyproject.toml")), Location(Path("pyproject.toml"))
             ),
             DEP003TransitiveDependencyViolation(
-                Module("foo", package="foo_package"), Location(Path("foo/bar.py"), 1, 2)
+                Module("foo", package="foo-package"), Location(Path("foo/bar.py"), 1, 2)
             ),
-            DEP004MisplacedDevDependencyViolation(Module("foo", package="foo_package"), Location(Path("foo.py"), 1, 2)),
+            DEP004MisplacedDevDependencyViolation(Module("foo", package="foo-package"), Location(Path("foo.py"), 1, 2)),
         ]
         TextReporter(violations, use_ansi=False).report()
 
@@ -118,7 +118,7 @@ def test_logging_no_ansi(caplog: LogCaptureFixture) -> None:
         "",
         f"{Path('foo.py')}:1:2: DEP001 'foo' imported but missing from the dependency definitions",
         f"{Path('pyproject.toml')}: DEP002 'foo' defined as a dependency but not used in the codebase",
-        f"{Path('foo/bar.py')}:1:2: DEP003 'foo_package' imported but it is a transitive dependency",
+        f"{Path('foo/bar.py')}:1:2: DEP003 'foo' imported but it is a transitive dependency",
         f"{Path('foo.py')}:1:2: DEP004 'foo' imported but declared as a dev dependency",
         "Found 4 dependency issues.",
         "\nFor more information, see the documentation: https://deptry.com/",


### PR DESCRIPTION
Resolves #643.

**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [x] If there is a related issue, make sure it is linked to this PR.
-   [x] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

We currently show the package name for DEP003, but ignore rules take the Python module name into account for DEP003, not the package name. So this PR updates the report to show the Python module name instead.

We might want to consider switching to the package name for the ignore rule, and show the package name in the report as well, but this would technically be a breaking change for users that already define ignore rules and use the Python module name, so I'd prefer to go with this fix for now.