### PR TITLE
chore(deps): bump `pyo3` to 0.21.0 and `pyo3-log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c10808ee7250403bedb24bc30c32493e93875fef7ba3e4292226fe924f398bd"
+checksum = "2af49834b8d2ecd555177e63b273b708dea75150abc6f5341d0a6e1a9623976c"
 dependencies = [
  "arc-swap",
  "log",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ encoding_rs = "0.8.34"
 ignore = "0.4.22"
 log = "0.4.21"
 path-slash = "0.2.1"
-pyo3 = { version = "0.20.3", features = ["abi3-py38"] }
-pyo3-log = "0.9.0"
+pyo3 = { version = "0.21.2", features = ["abi3-py38", "gil-refs"] }
+pyo3-log = "0.10.0"
 rayon = "1.10.0"
 regex = "1.10.4"
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "v0.4.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ encoding_rs = "0.8.34"
 ignore = "0.4.22"
 log = "0.4.21"
 path-slash = "0.2.1"
-pyo3 = { version = "0.21.2", features = ["abi3-py38", "gil-refs"] }
+pyo3 = { version = "0.21.2", features = ["abi3-py38"] }
 pyo3-log = "0.10.0"
 rayon = "1.10.0"
 regex = "1.10.4"

--- a/src/imports/shared.rs
+++ b/src/imports/shared.rs
@@ -78,14 +78,14 @@ pub fn convert_to_python_dict(
     py: Python<'_>,
     imports_with_locations: FileToImportsMap,
 ) -> PyResult<PyObject> {
-    let imports_dict = PyDict::new(py);
+    let imports_dict = PyDict::new_bound(py);
 
     for (module, locations) in imports_with_locations {
         let py_locations: Vec<PyObject> = locations
             .into_iter()
             .map(|location| location.into_py(py))
             .collect();
-        let locations_list = PyList::new(py, &py_locations);
+        let locations_list = PyList::new_bound(py, &py_locations);
         imports_dict.set_item(module, locations_list)?;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod visitor;
 use location::Location;
 
 #[pymodule]
-fn rust(_py: Python, m: &PyModule) -> PyResult<()> {
+fn rust(_py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     pyo3_log::init(); // Initialize logging to forward to Python's logger
 
     m.add_function(wrap_pyfunction!(imports::py::get_imports_from_py_files, m)?)?;

--- a/src/python_file_finder.rs
+++ b/src/python_file_finder.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 pub fn find_python_files(
     py: Python,
     directories: Vec<PathBuf>,
-    exclude: Vec<&str>,
-    extend_exclude: Vec<&str>,
+    exclude: Vec<String>,
+    extend_exclude: Vec<String>,
     using_default_exclude: bool,
     ignore_notebooks: bool,
 ) -> PyResult<PyObject> {
@@ -37,12 +37,12 @@ pub fn find_python_files(
     })
     .collect();
 
-    Ok(PyList::new(py, &python_files).into())
+    Ok(PyList::new_bound(py, &python_files).into())
 }
 
 fn build_walker(
     directories: Vec<PathBuf>,
-    excluded_patterns: Vec<&str>,
+    excluded_patterns: Vec<String>,
     use_git_ignore: bool,
     ignore_notebooks: bool,
 ) -> Walk {


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

Bump `pyo3` to 0.21 following [this migration guide](https://pyo3.rs/v0.21.1/migration). Bump of `pyo3-log` is also needed, as the current version does not support `pyo3` 0.21.