### PR TITLE
ci: tweak workflows

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   python-version:
     description: 'Python version for setup-python'
     required: true
-    default: 3.11
+    default: '3.12'
   target:
     description: 'Target architecture for maturin'
     required: true

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -10,10 +10,6 @@ inputs:
     description: 'Target architecture for maturin'
     required: true
     default: 'x86_64'
-  python-target:
-    description: 'Target architecture for python installation'
-    required: true
-    default: 'x64'
 
 runs:
   using: 'composite'
@@ -22,7 +18,6 @@ runs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
-        architecture: ${{ matrix.python-target }}
 
     - name: Setup Rust toolchain
       run: rustup component add clippy rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-env
         with:
-          python-version: '3.11'
           target: 'x86_64'
           python-target: 'x64'
 
@@ -59,11 +58,11 @@ jobs:
       - name: Run functional tests
         run: pdm run pytest tests/functional -n auto --dist loadgroup
 
-      - name: Upload coverage reports to Codecov with GitHub Action on Python 3.11 and x86_64
+      - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.python-version == '3.11' && matrix.target == 'x86_64' }}
+        if: ${{ matrix.python-version == '3.12' && matrix.target == 'x86_64' }}
 
   windows:
     runs-on: windows-2022
@@ -120,7 +119,6 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-env
         with:
-          python-version: '3.11'
           target: 'x86_64'
 
       - name: Check if documentation can be built

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,6 @@ jobs:
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
-        with:
-          target: 'x86_64'
-          python-target: 'x64'
 
       - name: Run pre-commit
         run: |
@@ -37,7 +34,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target: [x86_64, aarch64]
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -46,8 +42,6 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-          target: ${{ matrix.target }}
-          python-target: 'x64'
 
       - name: Check typing
         run: pdm run mypy
@@ -62,14 +56,13 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.python-version == '3.12' && matrix.target == 'x86_64' }}
+        if: ${{ matrix.python-version == '3.12' }}
 
   windows:
     runs-on: windows-2022
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target: [x64]
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -78,8 +71,6 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-          target: ${{ matrix.target }}
-          python-target: ${{ matrix.target }}
 
       - name: Run unit tests
         run: pdm run pytest tests/unit --cov --cov-config=pyproject.toml --cov-report=xml
@@ -92,7 +83,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
-        target: [x86_64, aarch64]
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -101,8 +91,6 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           python-version: ${{ matrix.python-version }}
-          target: ${{ matrix.target }}
-          python-target: ${{ matrix.target == 'aarch64' && 'arm64' || 'x64' }}
 
       - name: Run unit tests
         run: pdm run pytest tests/unit --cov --cov-config=pyproject.toml --cov-report=xml
@@ -118,8 +106,6 @@ jobs:
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
-        with:
-          target: 'x86_64'
 
       - name: Check if documentation can be built
         run: pdm run mkdocs build -s

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   quality:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
           pdm run deptry python
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -66,7 +66,7 @@ jobs:
         if: ${{ matrix.python-version == '3.11' && matrix.target == 'x86_64' }}
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -89,7 +89,7 @@ jobs:
         run: pdm run pytest tests/functional -n auto --dist loadgroup
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
@@ -112,7 +112,7 @@ jobs:
         run: pdm run pytest tests/functional -n auto --dist loadgroup
 
   check-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
         run: pdm run pytest tests/functional -n auto --dist loadgroup
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-13
     needs: [set-version]
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   set-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -27,7 +27,7 @@ jobs:
           path: pyproject.toml
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [set-version]
     strategy:
       matrix:
@@ -62,7 +62,7 @@ jobs:
           path: dist
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [set-version]
     strategy:
       matrix:
@@ -97,7 +97,7 @@ jobs:
           path: dist
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: [set-version]
     strategy:
       matrix:
@@ -136,7 +136,7 @@ jobs:
           path: dist
 
   sdist:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [set-version]
     steps:
       - uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4
@@ -174,7 +174,7 @@ jobs:
           args: --non-interactive --skip-existing wheels-*/*
 
   check-docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish
     steps:
       - name: Check out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.11', 'pypy3.10']
+        python: ['3.12', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python: ['3.11', 'pypy3.10']
+        python: ['3.12', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.11']
+        python: ['3.12']
         include:
           # It seems PyPy3.10 is not available on macOS arm64 yet
           - target: x86_64
@@ -183,7 +183,6 @@ jobs:
       - name: Set up the environment
         uses: ./.github/actions/setup-env
         with:
-          python-version: '3.11'
           target: 'x86_64'
 
       - name: Deploy documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-          architecture: 'x64'
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -81,7 +80,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.target }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -120,7 +118,6 @@ jobs:
         id: setup-python
         with:
           python-version: ${{ matrix.python }}
-          architecture: ${{ matrix.target == 'aarch64' && 'arm64' || 'x64' }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -182,8 +179,6 @@ jobs:
 
       - name: Set up the environment
         uses: ./.github/actions/setup-env
-        with:
-          target: 'x86_64'
 
       - name: Deploy documentation
         run: pdm run mkdocs gh-deploy --force


### PR DESCRIPTION
**PR Checklist**

-   [x] A description of the changes is added to the description of this PR.
-   [ ] If there is a related issue, make sure it is linked to this PR.
-   [ ] If you've fixed a bug or added code that should be tested, add tests!
-   [ ] Documentation in `docs` is updated

**Description of changes**

https://github.com/fpgmaas/deptry/actions/runs/8523309964/job/23345314629 shows that ARM jobs in testing don't actually use ARM (which is not really surprising, since we only use `x86_64` images). For instance, we can see:
```console
Downloading zstandard-0.22.0-cp310-cp310-macosx_10_9_x86_64.whl (920 kB)
```

To test against ARM, we would need to use ARM images (which only exist for macOS on GitHub Actions). I don't believe that using ARM brings that much values for tests, so it's probably not worth handling that for macOS (although we can still reconsider that later).

This PR also does 2 main other things:
- use explicit versions for runner images, because:
  - `latest` is a moving target that could change and break things -- for instance on `macos-latest`, `latest` will soon switch from `macos-12` to `macos-14`, changing the image from `x86_64` to `aarch64` (see [this](https://github.blog/changelog/2024-04-01-macos-14-sonoma-is-generally-available-and-the-latest-macos-runner-image/) and [this](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/)), and macOS ARM images only have Python >= 3.10 preinstalled, so this would have broken our builds testing against Python 3.8 and 3.9
  - Renovate detects and is able to bump GitHub Actions runner images
- test against `pypy3.10` on Linux, to ensure that tests pass against PyPy, as we build wheels for PyPy 3.10 during release (since the job is way slower than CPython ones, especially on macOS and Windows, I think testing only on Linux, at least for now, could be a good tradeoff)

Before we merge this PR (or right after it is merged, if we manually merge them), we will need to update the list of required jobs, to reflect the changes.