### PR TITLE
fix(visitor): skip type checking blocks without future annotations

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -47,9 +47,8 @@ Imports will be extracted regardless of where they are made in a file (top-level
 conditions, ...).
 
 The only exception is imports that are guarded
-by [`TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) when
-using `from __future__ import annotations`, in accordance with [PEP 563](https://peps.python.org/pep-0563/). In this
-specific case, _deptry_ will not extract those imports, as they are not considered problematic. For instance:
+by [`TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING). In this specific case,
+_deptry_ will not extract those imports, as they are not considered problematic. For instance:
 
 ```python
 from __future__ import annotations

--- a/tests/data/some_imports.py
+++ b/tests/data/some_imports.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import typing
 from os import chdir, walk
 from pathlib import Path

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -21,26 +21,25 @@ def test_import_parser_py() -> None:
     some_imports_path = Path("tests/data/some_imports.py")
 
     assert get_imported_modules_from_list_of_files([some_imports_path]) == {
-        "__future__": [Location(some_imports_path, 1, 1)],
-        "barfoo": [Location(some_imports_path, 23, 8)],
-        "baz": [Location(some_imports_path, 19, 5)],
-        "click": [Location(some_imports_path, 33, 12)],
-        "foobar": [Location(some_imports_path, 21, 12)],
-        "httpx": [Location(some_imports_path, 17, 12)],
-        "module_in_class": [Location(some_imports_path, 44, 16)],
-        "module_in_func": [Location(some_imports_path, 39, 12)],
-        "not_click": [Location(some_imports_path, 35, 12)],
+        "barfoo": [Location(some_imports_path, 21, 8)],
+        "baz": [Location(some_imports_path, 17, 5)],
+        "click": [Location(some_imports_path, 31, 12)],
+        "foobar": [Location(some_imports_path, 19, 12)],
+        "httpx": [Location(some_imports_path, 15, 12)],
+        "module_in_class": [Location(some_imports_path, 42, 16)],
+        "module_in_func": [Location(some_imports_path, 37, 12)],
+        "not_click": [Location(some_imports_path, 33, 12)],
         "numpy": [
-            Location(some_imports_path, 8, 8),
-            Location(some_imports_path, 10, 1),
+            Location(some_imports_path, 6, 8),
+            Location(some_imports_path, 8, 1),
         ],
-        "os": [Location(some_imports_path, 4, 1)],
-        "pandas": [Location(some_imports_path, 9, 8)],
-        "pathlib": [Location(some_imports_path, 5, 1)],
-        "randomizer": [Location(some_imports_path, 24, 1)],
+        "os": [Location(some_imports_path, 2, 1)],
+        "pandas": [Location(some_imports_path, 7, 8)],
+        "pathlib": [Location(some_imports_path, 3, 1)],
+        "randomizer": [Location(some_imports_path, 22, 1)],
         "typing": [
-            Location(some_imports_path, 3, 8),
-            Location(some_imports_path, 6, 1),
+            Location(some_imports_path, 1, 8),
+            Location(some_imports_path, 4, 1),
         ],
     }
 


### PR DESCRIPTION
Resolves #661.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Implementation in https://github.com/fpgmaas/deptry/pull/652 was a bit too defensive, for invalid reasons. `from __future__ import annotations` is not relevant in the context of `deptry`, as not using it will still allows setting types but in quotes. So we should also skip those imports when a module does not use `from __future__ import annotations`.