### PR TITLE
test(conftest): ensure that `pytest_sessionstart` hook runs once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ warn_unreachable = true
 pretty = true
 show_error_codes = true
 
+[[tool.mypy.overrides]]
+module = ["xdist.*"]
+ignore_missing_imports = true
+
 [tool.deptry]
 extend_exclude = [
     "docs",

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -6,12 +6,20 @@ import sys
 from pathlib import Path
 
 import pytest
+import xdist
 
 from tests.functional.utils import DEPTRY_WHEEL_DIRECTORY
 from tests.utils import PDMVenvFactory, PipVenvFactory, PoetryVenvFactory
 
 
-def pytest_sessionstart() -> None:
+def pytest_sessionstart(session: pytest.Session) -> None:
+    # When running the tests on multiple workers with pytest-xdist, the hook will be run several times:
+    # - once from "master" node, when test suite starts
+    # - X times (where X is the number of workers), when tests start in each worker
+    # We only want to run the hook once, so we explicitly skip the hook if running on a pytest-xdist worker.
+    if xdist.is_xdist_worker(session):
+        return None
+
     deptry_wheel_path = Path(DEPTRY_WHEEL_DIRECTORY)
 
     print(f"Building `deptry` wheel in {deptry_wheel_path} to use it on functional tests...")  # noqa: T201


### PR DESCRIPTION
Resolves https://github.com/fpgmaas/deptry/issues/636.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Contrarily to what I though, running tests on multiple workers with `pytest-xdist` will run `pytest_sessionstart` several times:
- once from "master" node, when test suite starts
- X times (where X is the number of workers), when tests start in each worker

This was not obvious because the message we print in `pytest_sessionstart` is not displayed in workers, but this can easily be reproduced with:

```python
import uuid

def pytest_sessionstart() -> None:
    with open(str(uuid.uuid4()), "w"):
        pass
```

then running:

```shell
pdm run pytest tests/functional -n 2 --dist loadgroup
```

which will end up creating 3 files.

Since in our case we only want to run the hook once, we want to explicitly skip the hook if running on a `pytest-xdist` worker. For this we can use [xdist.is_xdist_worker](https://pytest-xdist.readthedocs.io/en/stable/how-to.html#xdist.is_xdist_worker). Not doing so, what probably happens and causes random test failures is that we have a race condition where multiple workers could write the same wheel file at the same time.

Aside from the race condition fix, since we don't rebuild the wheel twice sequentially for each worker, we also save CI time (see [this PR's workflow](https://github.com/fpgmaas/deptry/actions/runs/8587947049/usage) compared to [a previous one](https://github.com/fpgmaas/deptry/actions/runs/8581287883/usage)).