### PR TITLE
chore(pre-commit): check lock files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,21 @@ repos:
         args: [--exit-non-zero-on-fix]
       - id: ruff-format
 
+  - repo: https://github.com/pdm-project/pdm
+    rev: "2.15.1"
+    hooks:
+      - id: pdm-lock-check
+
+  - repo: local
+    hooks:
+      - id: cargo-check-lock
+        name: check cargo lock file validity
+        entry: cargo check
+        args: ["--locked", "--all-targets", "--all-features"]
+        language: system
+        pass_filenames: false
+        files: ^Cargo.toml$
+
   - repo: local
     hooks:
       - id: cargo-fmt

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
         args: ["--locked", "--all-targets", "--all-features"]
         language: system
         pass_filenames: false
-        files: ^Cargo.toml$
+        files: ^Cargo\.toml$
 
   - repo: local
     hooks:

--- a/renovate.json5
+++ b/renovate.json5
@@ -53,16 +53,4 @@
       customChangelogUrl: "https://github.com/charliermarsh/ruff",
     },
   ],
-
-  // https://docs.renovatebot.com/configuration-options/#custommanagers
-  customManagers: [
-    {
-      description: "Update Ruff in Cargo.toml",
-      customType: "regex",
-      fileMatch: ["^Cargo\\.toml$"],
-      matchStrings: ['git = "https:\/\/github.com\/astral-sh\/ruff", tag = "v(?<currentValue>.*?)"'],
-      datasourceTemplate: "pypi",
-      depNameTemplate: "ruff",
-    },
-  ],
 }


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

I feel dumb for not thinking about this, but the implementation in https://github.com/fpgmaas/deptry/pull/692 does not work as expected, as this will not refresh `Cargo.lock`, as can be seen in https://github.com/fpgmaas/deptry/pull/694 (since Renovate doesn't handle the dependency as a Cargo one). So this PR removes this, but also adds lock files check, which would have prevented the PR updating Ruff from getting merged, as the lock file was inconsistent.