### PR TITLE
refactor(dependency): remove unused optional/conditional

### DIFF
--- a/python/deptry/dependency.py
+++ b/python/deptry/dependency.py
@@ -20,8 +20,6 @@ class Dependency:
     Attributes:
         name (str): The name of the dependency.
         definition_file (Path): The path to the file defining the dependency, e.g. 'pyproject.toml'.
-        is_conditional (bool): Indicates if the dependency is conditional.
-        is_optional (bool): Indicates if the dependency is optional i.e. dependencies that are not installed by default
           and that can be used to create a variant of the package with a set of extra functionalities.
         found (bool): Indicates if the dependency has been found in the environment.
         top_levels (set[str]): The top-level module names associated with the dependency.
@@ -31,16 +29,12 @@ class Dependency:
         self,
         name: str,
         definition_file: Path,
-        conditional: bool = False,
-        optional: bool = False,
         module_names: Sequence[str] | None = None,
     ) -> None:
         distribution = self.find_distribution(name)
 
         self.name = name
         self.definition_file = definition_file
-        self.is_conditional = conditional
-        self.is_optional = optional
         self.found = distribution is not None
         self.top_levels = self._get_top_levels(name, distribution, module_names)
 
@@ -84,7 +78,7 @@ class Dependency:
         return f"Dependency '{self.name}'"
 
     def __str__(self) -> str:
-        return f"Dependency '{self.name}'{self._string_for_printing()}with top-levels: {self.top_levels}."
+        return f"Dependency '{self.name}' with top-levels: {self.top_levels}."
 
     @staticmethod
     def find_distribution(name: str) -> Distribution | None:
@@ -92,21 +86,6 @@ class Dependency:
             return metadata.distribution(name)
         except metadata.PackageNotFoundError:
             return None
-
-    def _string_for_printing(self) -> str:
-        """
-        Return 'Conditional', 'Optional' or 'Conditional and optional'
-        """
-        output_list = []
-        if self.is_optional:
-            output_list.append("optional")
-        if self.is_conditional:
-            output_list.append("conditional")
-
-        if len(output_list) > 0:
-            return f" ({', '.join(output_list)}) "
-        else:
-            return " "
 
     @staticmethod
     def _get_top_level_module_names_from_top_level_txt(distribution: Distribution) -> set[str]:

--- a/python/deptry/dependency_getter/pep_621.py
+++ b/python/deptry/dependency_getter/pep_621.py
@@ -114,21 +114,11 @@ class PEP621DependencyGetter(DependencyGetter):
                     Dependency(
                         name,
                         self.config,
-                        conditional=self._is_conditional(spec),
-                        optional=self._is_optional(spec),
                         module_names=package_module_name_map.get(name),
                     )
                 )
 
         return extracted_dependencies
-
-    @staticmethod
-    def _is_optional(dependency_specification: str) -> bool:
-        return bool(re.findall(r"\[([a-zA-Z0-9-]+?)\]", dependency_specification))
-
-    @staticmethod
-    def _is_conditional(dependency_specification: str) -> bool:
-        return ";" in dependency_specification
 
     @staticmethod
     def _find_dependency_name_in(spec: str) -> str | None:

--- a/python/deptry/dependency_getter/poetry.py
+++ b/python/deptry/dependency_getter/poetry.py
@@ -53,34 +53,8 @@ class PoetryDependencyGetter(DependencyGetter):
     def _get_dependencies(
         self, poetry_dependencies: dict[str, Any], package_module_name_map: Mapping[str, Sequence[str]]
     ) -> list[Dependency]:
-        dependencies = []
-        for dep, spec in poetry_dependencies.items():
-            # dep is the dependency name, spec is the version specification, e.g. "^0.2.2" or {"*", optional = true}
-            if dep != "python":
-                optional = self._is_optional(spec)
-                conditional = self._is_conditional(spec)
-                dependencies.append(
-                    Dependency(
-                        dep,
-                        self.config,
-                        conditional=conditional,
-                        optional=optional,
-                        module_names=package_module_name_map.get(dep),
-                    )
-                )
-
-        return dependencies
-
-    @staticmethod
-    def _is_optional(spec: str | dict[str, Any]) -> bool:
-        """
-        If a dependency specification is of the shape `isodate = {version = "*", optional = true}`, mark it as optional.
-        """
-        return bool(isinstance(spec, dict) and spec.get("optional"))
-
-    @staticmethod
-    def _is_conditional(spec: str | dict[str, Any]) -> bool:
-        """
-        If a dependency specification is of the shape `tomli = { version = "^2.0.1", python = "<3.11" }`, mark it as conditional.
-        """
-        return isinstance(spec, dict) and "python" in spec and "version" in spec
+        return [
+            Dependency(dep, self.config, module_names=package_module_name_map.get(dep))
+            for dep in poetry_dependencies
+            if dep != "python"
+        ]

--- a/python/deptry/dependency_getter/requirements_files.py
+++ b/python/deptry/dependency_getter/requirements_files.py
@@ -70,14 +70,9 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
         line = self._remove_newlines_from(line)
         name = self._find_dependency_name_in(line)
         if name:
-            line = line.replace(name, "")
-            optional = self._check_if_dependency_is_optional(line)
-            conditional = self._check_if_dependency_is_conditional(line)
             return Dependency(
                 name=name,
                 definition_file=file_path,
-                optional=optional,
-                conditional=conditional,
                 module_names=self.package_module_name_map.get(name),
             )
         else:
@@ -107,14 +102,6 @@ class RequirementsTxtDependencyGetter(DependencyGetter):
     @staticmethod
     def _remove_newlines_from(line: str) -> str:
         return line.replace("\n", "")
-
-    @staticmethod
-    def _check_if_dependency_is_optional(line: str) -> bool:
-        return bool(re.findall(r"\[([a-zA-Z0-9-]+?)\]", line))
-
-    @staticmethod
-    def _check_if_dependency_is_conditional(line: str) -> bool:
-        return ";" in line
 
     @staticmethod
     def _line_is_url(line: str) -> bool:

--- a/tests/unit/dependency_getter/test_pdm.py
+++ b/tests/unit/dependency_getter/test_pdm.py
@@ -33,28 +33,18 @@ dependencies = [
         assert len(dependencies) == 5
 
         assert dependencies[0].name == "qux"
-        assert not dependencies[0].is_conditional
-        assert not dependencies[0].is_optional
         assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "bar"
-        assert not dependencies[1].is_conditional
-        assert not dependencies[1].is_optional
         assert "bar" in dependencies[1].top_levels
 
         assert dependencies[2].name == "optional-foo"
-        assert not dependencies[2].is_conditional
-        assert dependencies[2].is_optional
         assert "optional_foo" in dependencies[2].top_levels
 
         assert dependencies[3].name == "conditional-bar"
-        assert dependencies[3].is_conditional
-        assert not dependencies[3].is_optional
         assert "conditional_bar" in dependencies[3].top_levels
 
         assert dependencies[4].name == "fox-python"
-        assert not dependencies[4].is_conditional
-        assert not dependencies[4].is_optional
         assert "fox" in dependencies[4].top_levels
 
 
@@ -88,16 +78,10 @@ tox = [
         assert len(dev_dependencies) == 3
 
         assert dev_dependencies[0].name == "qux"
-        assert not dev_dependencies[0].is_conditional
-        assert not dev_dependencies[0].is_optional
         assert "qux" in dev_dependencies[0].top_levels
 
         assert dev_dependencies[1].name == "bar"
-        assert dev_dependencies[1].is_conditional
-        assert not dev_dependencies[1].is_optional
         assert "bar" in dev_dependencies[1].top_levels
 
         assert dev_dependencies[2].name == "foo-bar"
-        assert not dev_dependencies[2].is_conditional
-        assert not dev_dependencies[2].is_optional
         assert "foo_bar" in dev_dependencies[2].top_levels

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -46,43 +46,27 @@ group2 = [
         assert len(dependencies) == 8
 
         assert dependencies[0].name == "qux"
-        assert not dependencies[0].is_conditional
-        assert not dependencies[0].is_optional
         assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "bar"
-        assert not dependencies[1].is_conditional
-        assert not dependencies[1].is_optional
         assert "bar" in dependencies[1].top_levels
 
         assert dependencies[2].name == "optional-foo"
-        assert not dependencies[2].is_conditional
-        assert dependencies[2].is_optional
         assert "optional_foo" in dependencies[2].top_levels
 
         assert dependencies[3].name == "conditional-bar"
-        assert dependencies[3].is_conditional
-        assert not dependencies[3].is_optional
         assert "conditional_bar" in dependencies[3].top_levels
 
         assert dependencies[4].name == "fox-python"
-        assert not dependencies[4].is_conditional
-        assert not dependencies[4].is_optional
         assert "fox" in dependencies[4].top_levels
 
         assert dependencies[5].name == "foobar"
-        assert not dependencies[5].is_conditional
-        assert not dependencies[5].is_optional
         assert "foobar" in dependencies[5].top_levels
 
         assert dependencies[6].name == "barfoo"
-        assert not dependencies[6].is_conditional
-        assert not dependencies[6].is_optional
         assert "barfoo" in dependencies[6].top_levels
 
         assert dependencies[7].name == "dep"
-        assert not dependencies[7].is_conditional
-        assert not dependencies[7].is_optional
         assert "dep" in dependencies[7].top_levels
 
 
@@ -114,19 +98,13 @@ group2 = [
         assert len(dependencies) == 2
 
         assert dependencies[0].name == "qux"
-        assert not dependencies[0].is_conditional
-        assert not dependencies[0].is_optional
         assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "foobar"
-        assert not dependencies[1].is_conditional
-        assert not dependencies[1].is_optional
         assert "foobar" in dependencies[1].top_levels
 
         assert len(dev_dependencies) == 1
         assert dev_dependencies[0].name == "barfoo"
-        assert not dev_dependencies[0].is_conditional
-        assert not dev_dependencies[0].is_optional
         assert "barfoo" in dev_dependencies[0].top_levels
 
 
@@ -162,16 +140,10 @@ group2 = [
         assert len(dependencies) == 3
 
         assert dependencies[0].name == "qux"
-        assert not dependencies[0].is_conditional
-        assert not dependencies[0].is_optional
         assert "qux" in dependencies[0].top_levels
 
         assert dependencies[1].name == "foobar"
-        assert not dependencies[1].is_conditional
-        assert not dependencies[1].is_optional
         assert "foobar" in dependencies[1].top_levels
 
         assert dependencies[2].name == "barfoo"
-        assert not dependencies[2].is_conditional
-        assert not dependencies[2].is_optional
         assert "barfoo" in dependencies[2].top_levels

--- a/tests/unit/dependency_getter/test_poetry.py
+++ b/tests/unit/dependency_getter/test_poetry.py
@@ -43,46 +43,28 @@ pytest-cov = "^4.0.0"
         assert len(dev_dependencies) == 6
 
         assert dependencies[0].name == "bar"
-        assert dependencies[0].is_conditional
-        assert not dependencies[0].is_optional
         assert "bar" in dependencies[0].top_levels
 
         assert dependencies[1].name == "foo-bar"
-        assert dependencies[1].is_conditional
-        assert dependencies[1].is_optional
         assert "foo_bar" in dependencies[1].top_levels
 
         assert dependencies[2].name == "fox-python"
-        assert not dependencies[2].is_conditional
-        assert not dependencies[2].is_optional
         assert "fox" in dependencies[2].top_levels
 
         assert dev_dependencies[0].name == "toml"
-        assert not dev_dependencies[0].is_conditional
-        assert not dev_dependencies[0].is_optional
         assert "toml" in dev_dependencies[0].top_levels
 
         assert dev_dependencies[1].name == "qux"
-        assert not dev_dependencies[1].is_conditional
-        assert dev_dependencies[1].is_optional
         assert "qux" in dev_dependencies[1].top_levels
 
         assert dev_dependencies[2].name == "black"
-        assert not dev_dependencies[2].is_conditional
-        assert not dev_dependencies[2].is_optional
         assert "black" in dev_dependencies[2].top_levels
 
         assert dev_dependencies[3].name == "mypy"
-        assert not dev_dependencies[3].is_conditional
-        assert not dev_dependencies[3].is_optional
         assert "mypy" in dev_dependencies[3].top_levels
 
         assert dev_dependencies[4].name == "pytest"
-        assert not dev_dependencies[4].is_conditional
-        assert not dev_dependencies[4].is_optional
         assert "pytest" in dev_dependencies[4].top_levels
 
         assert dev_dependencies[5].name == "pytest-cov"
-        assert not dev_dependencies[5].is_conditional
-        assert not dev_dependencies[5].is_optional
         assert "pytest_cov" in dev_dependencies[5].top_levels

--- a/tests/unit/dependency_getter/test_requirements_txt.py
+++ b/tests/unit/dependency_getter/test_requirements_txt.py
@@ -46,23 +46,15 @@ httpx==0.25.2
         assert len(dependencies_extract.dev_dependencies) == 0
 
         assert dependencies[1].name == "colorama"
-        assert not dependencies[1].is_conditional
-        assert not dependencies[1].is_optional
         assert "colorama" in dependencies[1].top_levels
 
         assert dependencies[2].name == "importlib-metadata"
-        assert dependencies[2].is_conditional
-        assert not dependencies[2].is_optional
         assert "importlib_metadata" in dependencies[2].top_levels
 
         assert dependencies[11].name == "requests"
-        assert dependencies[11].is_conditional
-        assert dependencies[11].is_optional
         assert "requests" in dependencies[11].top_levels
 
         assert dependencies[17].name == "fox-python"
-        assert not dependencies[17].is_conditional
-        assert not dependencies[17].is_optional
         assert "fox" in dependencies[17].top_levels
 
 
@@ -142,8 +134,6 @@ def test_dev_single(tmp_path: Path) -> None:
         assert len(dev_dependencies) == 2
 
         assert dev_dependencies[1].name == "colorama"
-        assert not dev_dependencies[1].is_conditional
-        assert not dev_dependencies[1].is_optional
         assert "colorama" in dev_dependencies[1].top_levels
 
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Noticed that we never use optional/conditional information apart from `Dependency.__str__`. This might be something that could be used in the future, but if we do need it at some point, the code will be in git history, so IMO we might as well remove code if we don't need it.