### PR TITLE
add support for dynamic dependencies with setuptools

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,11 +38,13 @@ To determine the project's dependencies, _deptry_ will scan the directory it is 
     - dependencies from `[project.dependencies]` and `[project.optional-dependencies]` sections
     - development dependencies from `[tool.pdm.dev-dependencies]` section and from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
 3. If a `pyproject.toml` file containing the following is found:
-    1. a `[build-system]` section containing `build-backend = "setuptools.build_meta"`,
-    2. a `[project]` section a list of `dynamic` values containing `dependencies`,
-    3. a `[tools.setuptools.dynamic]` section containing `dependencies = { file = some_requirements_file }`,
-   then _deptry_ will assume it uses setuptools project with dynamic dependencies and extract dependencies 
-   from the file specified in the `[tools.setuptools.dynamic]` section.
+    1. a `[build-system]` section containing `build-backend = "setuptools.build_meta"` and,
+    2. a `[project]` section with a `dynamic` key, where the corresponding list includes `"dependencies"` and,
+    3. a `[tool.setuptools.dynamic]` section containing `dependencies = { file = [some_requirements_file] }`,
+
+    then _deptry_ will assume the project uses setuptools with dynamic dependencies. It will extract dependencies 
+    from the file specified in the `[tool.setuptools.dynamic]` section.
+
 4. If a `pyproject.toml` file with a `[project]` section is found, _deptry_ will assume it uses [PEP 621](https://peps.python.org/pep-0621/) for dependency specification and extract:
     - dependencies from `[project.dependencies]` and `[project.optional-dependencies]`.
     - development dependencies from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -37,10 +37,16 @@ To determine the project's dependencies, _deptry_ will scan the directory it is 
 2. If a `pyproject.toml` file with a `[tool.pdm.dev-dependencies]` section is found, _deptry_ will assume it uses PDM and extract:
     - dependencies from `[project.dependencies]` and `[project.optional-dependencies]` sections
     - development dependencies from `[tool.pdm.dev-dependencies]` section and from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
-3. If a `pyproject.toml` file with a `[project]` section is found, _deptry_ will assume it uses [PEP 621](https://peps.python.org/pep-0621/) for dependency specification and extract:
+3. If a `pyproject.toml` file containing the following is found:
+    1. a `[build-system]` section containing `build-backend = "setuptools.build_meta"`,
+    2. a `[project]` section a list of `dynamic` values containing `dependencies`,
+    3. a `[tools.setuptools.dynamic]` section containing `dependencies = { file = some_requirements_file }`,
+   then _deptry_ will assume it uses setuptools project with dynamic dependencies and extract dependencies 
+   from the file specified in the `[tools.setuptools.dynamic]` section.
+4. If a `pyproject.toml` file with a `[project]` section is found, _deptry_ will assume it uses [PEP 621](https://peps.python.org/pep-0621/) for dependency specification and extract:
     - dependencies from `[project.dependencies]` and `[project.optional-dependencies]`.
     - development dependencies from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
-4. If a `requirements.in` or `requirements.txt` file is found, _deptry_ will:
+5. If a `requirements.in` or `requirements.txt` file is found, _deptry_ will:
     - extract dependencies from that file.
     - extract development dependencies from `dev-dependencies.txt` and `dependencies-dev.txt`, if any exist
 

--- a/python/deptry/dependency_getter/builder.py
+++ b/python/deptry/dependency_getter/builder.py
@@ -113,14 +113,14 @@ class DependencyGetterBuilder:
                 pyproject_toml["tool"]["setuptools"]["dynamic"]["dependencies"]["file"]
                 logging.debug(
                     "pyproject.toml has dependencies listed as dynamic metadata"
-                    " and contains a populated tools.setuptools.dynamic.dependencies.file"
+                    " and contains a populated tool.setuptools.dynamic.dependencies.file"
                     " entry, so dynamic dependencies are used."
                 )
                 return True
         except KeyError:
             logging.debug(
                 "pyproject.toml either does not contain a project.dynamic entry or "
-                "tools.setuptools.dynamic.dependencies.file entry, so dynamic "
+                "tool.setuptools.dynamic.dependencies.file entry, so dynamic "
                 "dependencies are not used."
             )
             return False

--- a/python/deptry/dependency_getter/builder.py
+++ b/python/deptry/dependency_getter/builder.py
@@ -82,21 +82,21 @@ class DependencyGetterBuilder:
             if pyproject_toml["build-system"]["build-backend"] == "setuptools.build_meta":
                 logging.debug(
                     "pyproject.toml has the entry"
-                    " build-system.build-backend == 'setuptools.build-meta'"
-                    ", so setuptools is used to manage dependencies."
+                    " build-system.build-backend == 'setuptools.build_meta'"
+                    ", so setuptools is used to specify the project's dependencies."
                 )
                 return True
             else:
                 logging.debug(
                     "pyproject.toml does not have"
-                    " build-system.build-backend == 'setuptools.build-meta'"
-                    ", so setuptools is not used to manage dependencies."
+                    " build-system.build-backend == 'setuptools.build_meta'"
+                    ", so setuptools is not used to specify the project's dependencies."
                 )
                 return False
         except KeyError:
             logging.debug(
                 "pyproject.toml does not contain a build-system.build-backend entry, "
-                "so setuptools is not used to manage dependencies."
+                "so setuptools is not used to specify the project's dependencies."
             )
             return False
 

--- a/tests/data/project_with_dynamic_dependencies/pyproject.toml
+++ b/tests/data/project_with_dynamic_dependencies/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }

--- a/tests/data/project_with_dynamic_dependencies/requirements.txt
+++ b/tests/data/project_with_dynamic_dependencies/requirements.txt
@@ -1,0 +1,5 @@
+click==8.1.3
+isort==5.10.1
+pkginfo==1.8.3
+requests==2.28.1
+toml==0.10.2

--- a/tests/data/project_with_dynamic_dependencies/src/main.py
+++ b/tests/data/project_with_dynamic_dependencies/src/main.py
@@ -1,0 +1,6 @@
+from os import chdir, walk
+from pathlib import Path
+
+import click
+import white as w
+from urllib3 import contrib

--- a/tests/data/project_with_dynamic_dependencies/src/notebook.ipynb
+++ b/tests/data/project_with_dynamic_dependencies/src/notebook.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9f4924ec-2200-4801-9d49-d4833651cbc4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import click\n",
+    "from urllib3 import contrib\n",
+    "import toml"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/functional/cli/test_cli_dynamic_dependencies.py
+++ b/tests/functional/cli/test_cli_dynamic_dependencies.py
@@ -1,0 +1,105 @@
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.functional.utils import Project
+from tests.utils import get_issues_report
+
+if TYPE_CHECKING:
+    from tests.utils import PipVenvFactory
+
+
+@pytest.mark.xdist_group(name=Project.DYNAMIC_DEPENDENCIES)
+def test_cli_single_requirements_files(pip_venv_factory: PipVenvFactory) -> None:
+    with pip_venv_factory(
+        Project.DYNAMIC_DEPENDENCIES,
+        install_command=(
+            "pip install -r requirements.txt"
+        ),
+    ) as virtual_env:
+        issue_report = f"{uuid.uuid4()}.json"
+        result = virtual_env.run(
+            f"deptry . -o {issue_report}"
+        )
+
+        assert result.returncode == 1
+        assert get_issues_report(Path(issue_report)) == [
+            {
+                "error": {
+                    "code": "DEP002",
+                    "message": "'isort' defined as a dependency but not used in the codebase",
+                },
+                "module": "isort",
+                "location": {
+                    "file": str(Path("requirements.txt")),
+                    "line": None,
+                    "column": None,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP002",
+                    "message": "'pkginfo' defined as a dependency but not used in the codebase",
+                },
+                "module": "pkginfo",
+                "location": {
+                    "file": str(Path("requirements.txt")),
+                    "line": None,
+                    "column": None,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP002",
+                    "message": "'requests' defined as a dependency but not used in the codebase",
+                },
+                "module": "requests",
+                "location": {
+                    "file": str(Path("requirements.txt")),
+                    "line": None,
+                    "column": None,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP001",
+                    "message": "'white' imported but missing from the dependency definitions",
+                },
+                "module": "white",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 5,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP003",
+                    "message": "'urllib3' imported but it is a transitive dependency",
+                },
+                "module": "urllib3",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 6,
+                    "column": 1,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP003",
+                    "message": "'urllib3' imported but it is a transitive dependency",
+                },
+                "module": "urllib3",
+                "location": {
+                    "file": str(Path("src/notebook.ipynb")),
+                    "line": 2,
+                    "column": 1,
+                },
+            },
+        ]
+

--- a/tests/functional/cli/test_cli_dynamic_dependencies.py
+++ b/tests/functional/cli/test_cli_dynamic_dependencies.py
@@ -1,4 +1,3 @@
-
 from __future__ import annotations
 
 import uuid
@@ -18,14 +17,10 @@ if TYPE_CHECKING:
 def test_cli_single_requirements_files(pip_venv_factory: PipVenvFactory) -> None:
     with pip_venv_factory(
         Project.DYNAMIC_DEPENDENCIES,
-        install_command=(
-            "pip install -r requirements.txt"
-        ),
+        install_command=("pip install -r requirements.txt"),
     ) as virtual_env:
         issue_report = f"{uuid.uuid4()}.json"
-        result = virtual_env.run(
-            f"deptry . -o {issue_report}"
-        )
+        result = virtual_env.run(f"deptry . -o {issue_report}")
 
         assert result.returncode == 1
         assert get_issues_report(Path(issue_report)) == [
@@ -102,4 +97,3 @@ def test_cli_single_requirements_files(pip_venv_factory: PipVenvFactory) -> None
                 },
             },
         ]
-

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -17,7 +17,7 @@ class Project(str, Enum):
     REQUIREMENTS_TXT = "project_with_requirements_txt"
     REQUIREMENTS_IN = "project_with_requirements_in"
     SRC_DIRECTORY = "project_with_src_directory"
-    DYNAMIC_DEPENDENCIES = 'project_with_dynamic_dependencies'
+    DYNAMIC_DEPENDENCIES = "project_with_dynamic_dependencies"
 
     def __str__(self) -> str:
         return self.value

--- a/tests/functional/utils.py
+++ b/tests/functional/utils.py
@@ -17,6 +17,7 @@ class Project(str, Enum):
     REQUIREMENTS_TXT = "project_with_requirements_txt"
     REQUIREMENTS_IN = "project_with_requirements_in"
     SRC_DIRECTORY = "project_with_src_directory"
+    DYNAMIC_DEPENDENCIES = 'project_with_dynamic_dependencies'
 
     def __str__(self) -> str:
         return self.value

--- a/tests/unit/dependency_getter/test_builder.py
+++ b/tests/unit/dependency_getter/test_builder.py
@@ -131,6 +131,10 @@ def test_dependency_specification_not_found_raises_exception(tmp_path: Path, cap
             " project's dependencies."
         ),
         (
+            "pyproject.toml does not have build-system.build-backend == 'setuptools.build-meta', so setuptools is"
+            " not used to manage dependencies."
+        ),
+        (
             "pyproject.toml does not contain a [project] section, so PEP 621 is not used to specify the project's"
             " dependencies."
         ),

--- a/tests/unit/dependency_getter/test_builder.py
+++ b/tests/unit/dependency_getter/test_builder.py
@@ -83,6 +83,22 @@ def test_both(tmp_path: Path) -> None:
         spec = DependencyGetterBuilder(pyproject_toml_path).build()
         assert isinstance(spec, PoetryDependencyGetter)
 
+def test_setuptools_dynamic_dependencies(tmp_path: Path) -> None:
+    with run_within_dir(tmp_path):
+        with Path("requirements.txt").open('w') as f:
+            f.write('foo >= 1.0')
+        with Path("pyproject.toml").open('w') as f:
+            f.write('''
+            [build-system]
+            build-backend = "setuptools.build_meta"
+            [project]
+            dynamic = ["dependencies"]
+            [tool.setuptools.dynamic]
+            dependencies = {file = ["requirements.txt"]}
+            ''')
+
+        spec = DependencyGetterBuilder(Path("pyproject.toml")).build()
+        assert isinstance(spec, RequirementsTxtDependencyGetter)
 
 def test_requirements_files(tmp_path: Path) -> None:
     with run_within_dir(tmp_path):
@@ -131,8 +147,8 @@ def test_dependency_specification_not_found_raises_exception(tmp_path: Path, cap
             " project's dependencies."
         ),
         (
-            "pyproject.toml does not have build-system.build-backend == 'setuptools.build-meta', so setuptools is"
-            " not used to manage dependencies."
+            "pyproject.toml does not have build-system.build-backend == 'setuptools.build_meta', so setuptools is"
+            " not used to specify the project's dependencies."
         ),
         (
             "pyproject.toml does not contain a [project] section, so PEP 621 is not used to specify the project's"

--- a/tests/unit/dependency_getter/test_builder.py
+++ b/tests/unit/dependency_getter/test_builder.py
@@ -83,22 +83,24 @@ def test_both(tmp_path: Path) -> None:
         spec = DependencyGetterBuilder(pyproject_toml_path).build()
         assert isinstance(spec, PoetryDependencyGetter)
 
+
 def test_setuptools_dynamic_dependencies(tmp_path: Path) -> None:
     with run_within_dir(tmp_path):
-        with Path("requirements.txt").open('w') as f:
-            f.write('foo >= 1.0')
-        with Path("pyproject.toml").open('w') as f:
-            f.write('''
+        with Path("requirements.txt").open("w") as f:
+            f.write("foo >= 1.0")
+        with Path("pyproject.toml").open("w") as f:
+            f.write("""
             [build-system]
             build-backend = "setuptools.build_meta"
             [project]
             dynamic = ["dependencies"]
             [tool.setuptools.dynamic]
             dependencies = {file = ["requirements.txt"]}
-            ''')
+            """)
 
         spec = DependencyGetterBuilder(Path("pyproject.toml")).build()
         assert isinstance(spec, RequirementsTxtDependencyGetter)
+
 
 def test_requirements_files(tmp_path: Path) -> None:
     with run_within_dir(tmp_path):


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This pull request adds support for dependencies dynamically specified when using setuptools. This fixes #421. The changes should not affect users of setuptools that do not use dynamic dependencies, as in this case it will revert to the PEP621 compliant dependency checker.

Known issue: if the specified file to source dependencies from does not exist, this code will crash. @fpgmaas what is the best way to present this error to the user?