### PR TITLE
Remove rust cache

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -30,15 +30,13 @@ runs:
         PDM_VENV_WITH_PIP: "true"
       shell: bash
 
-    - name: Setup Rust toolchain
-      run: rustup component add clippy rustfmt
-      shell: bash
-
-    # - uses: Swatinem/rust-cache@v2
-
     - name: Build and install the project using Maturin
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ inputs.target }}
         command: develop
         sccache: 'true'
+
+    - name: Setup Rust toolchain
+      run: rustup component add clippy rustfmt
+      shell: bash

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -34,7 +34,7 @@ runs:
       run: rustup component add clippy rustfmt
       shell: bash
 
-    - uses: Swatinem/rust-cache@v2
+    # - uses: Swatinem/rust-cache@v2
 
     - name: Build and install the project using Maturin
       uses: PyO3/maturin-action@v1

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -24,12 +24,19 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     print(f"Building `deptry` wheel in {deptry_wheel_path} to use it on functional tests...")  # noqa: T201
 
-    subprocess.run(
-        shlex.split(f"pdm build --no-sdist --dest {deptry_wheel_path}", posix=sys.platform != "win32"),
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    try:
+        result = subprocess.run(
+            shlex.split(f"pdm build -v --no-sdist --dest {deptry_wheel_path}", posix=sys.platform != "win32"),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        print("pdm build output: %s", result.stdout)  # noqa: T201
+        print("pdm build errors: %s", result.stderr)  # noqa: T201
+    except subprocess.CalledProcessError as e:
+        print("Output: %s", e.output)  # noqa: T201
+        print("Errors: %s", e.stderr)  # noqa: T201
+        raise
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Recently our CI/CD pipeline failed during the functional tests on Windows in Github Actions. After adding some more verbose output to the tests, we can see that this is because we encounter errors while buiulding the wheel with maturin, see [here](https://github.com/fpgmaas/deptry/actions/runs/9429723770/job/25976421728). e.g.

```
 pdm.termui: error[E0463]: can't find crate for `pyo3`
pdm.termui:  --> src\lib.rs:3:5
pdm.termui:   |
pdm.termui: 3 | use pyo3::prelude::*;
pdm.termui:   |     ^^^^ can't find crate
```

After some testing, this seems to be caused by a problem with the cache. Taking a closer look at the [Swatinem/rust-cache@v2](https://github.com/Swatinem/rust-cache) step, I believe we are using it wrong and it might be superfluous. Their documentation says:

```
# selecting a toolchain either by action or manual `rustup` calls should happen
# before the plugin, as the cache uses the current rustc version as its cache key
```

But the installation of Rust is also handled by the `PyO3/maturin-action@v1` step, which comes after this step/

This PR proposes to remove the `Swatinem/rust-cache@v2` step.