### PR TITLE
feat: use `packaging` to parse requirements

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev", "docs", "typing"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:b5a073cc8f547affd7e1567d4210cdc344980819f9a16b66413d0a7ec2aadc3f"
+content_hash = "sha256:1b83e66fb8fdc2aaf4167ba3aec364b5de2487a487bcb3d504e3cd50ae697633"
 
 [[package]]
 name = "babel"
@@ -637,7 +637,7 @@ name = "packaging"
 version = "24.1"
 requires_python = ">=3.8"
 summary = "Core utilities for Python packages"
-groups = ["dev", "docs"]
+groups = ["default", "dev", "docs"]
 files = [
     {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
     {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "click>=8.0.0,<9",
     "colorama>=0.4.6; sys_platform == 'win32'",
+    "packaging>=22.0",
     "tomli>=2.0.1; python_version < '3.11'"
 ]
 

--- a/python/deptry/dependency.py
+++ b/python/deptry/dependency.py
@@ -4,7 +4,9 @@ import logging
 import re
 from contextlib import suppress
 from importlib import metadata
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
+
+from packaging.requirements import InvalidRequirement, Requirement
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -132,3 +134,18 @@ class Dependency:
         matches = re.finditer(r"^(?!__)([a-zA-Z0-9-_]+)(?:/|\.py,)", metadata_records, re.MULTILINE)
 
         return {x.group(1) for x in matches}
+
+
+def parse_pep_508_dependency(
+    specification: str, definition_file: Path, package_module_name_map: Mapping[str, Sequence[str]]
+) -> Dependency | None:
+    try:
+        requirement = Requirement(specification)
+    except InvalidRequirement:
+        return None
+
+    return Dependency(
+        name=requirement.name,
+        definition_file=definition_file,
+        module_names=package_module_name_map.get(requirement.name),
+    )

--- a/python/deptry/dependency_getter/pdm.py
+++ b/python/deptry/dependency_getter/pdm.py
@@ -50,4 +50,4 @@ class PDMDependencyGetter(PEP621DependencyGetter):
         except KeyError:
             logging.debug("No section [tool.pdm.dev-dependencies] found in pyproject.toml")
 
-        return self._extract_pep_508_dependencies(dev_dependency_strings, self.package_module_name_map)
+        return self._extract_pep_508_dependencies(dev_dependency_strings)

--- a/tests/unit/dependency_getter/test_pdm.py
+++ b/tests/unit/dependency_getter/test_pdm.py
@@ -15,7 +15,7 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
     "fox-python",  # top level module is called "fox"
 ]
 """
@@ -57,12 +57,12 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
 ]
 [tool.pdm.dev-dependencies]
 test = [
     "qux",
-    "bar; python_version < 3.11"
+    "bar; python_version < '3.11'"
     ]
 tox = [
     "foo-bar",

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -19,7 +19,7 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
     "fox-python",  # top level module is called "fox"
 ]
 

--- a/tests/unit/test_dependency.py
+++ b/tests/unit/test_dependency.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
 
 from deptry.dependency import Dependency, parse_pep_508_dependency
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def test_simple_dependency() -> None:

--- a/tests/unit/test_dependency.py
+++ b/tests/unit/test_dependency.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
-from deptry.dependency import Dependency
+import pytest
+
+from deptry.dependency import Dependency, parse_pep_508_dependency
 
 
 def test_simple_dependency() -> None:
@@ -99,3 +102,46 @@ def test_not_predefined_and_not_installed() -> None:
 
     assert dependency.name == "Foo-bar"
     assert dependency.top_levels == {"foo_bar"}
+
+
+@pytest.mark.parametrize(
+    ("specification", "definition_file", "package_module_name_map", "expected"),
+    [
+        (
+            "foo",
+            Path("pyproject.toml"),
+            {},
+            {
+                "name": "foo",
+                "definition_file": Path("pyproject.toml"),
+                "found": False,
+                "top_levels": {"foo"},
+            },
+        ),
+        (
+            'foobar[extra]==1.2.3; python_version < "3.9"',
+            Path("requirements.txt"),
+            {"foobar": ["foo"], "barfoo": ["bar"]},
+            {
+                "name": "foobar",
+                "definition_file": Path("requirements.txt"),
+                "found": False,
+                "top_levels": {"foo"},
+            },
+        ),
+    ],
+)
+def test_parse_pep_508_dependency(
+    specification: str,
+    definition_file: Path,
+    package_module_name_map: dict[str, list[str]],
+    expected: dict[str, Any],
+) -> None:
+    dependency = parse_pep_508_dependency(specification, definition_file, package_module_name_map)
+
+    for dependency_key, expected_value in expected.items():
+        assert getattr(dependency, dependency_key) == expected_value
+
+
+def test_parse_pep_508_dependency_invalid_definition() -> None:
+    assert parse_pep_508_dependency("an_incorrect_definition=1.2.3", Path("pyproject.toml"), {}) is None


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

This is something that has been on my mind for quite some time now.

We currently rely on several regexes to parse dependencies in requirements files. Although this allows parsing formats that `pip` handles, there are many formats that [PEP 508](https://peps.python.org/pep-0508/) does not cover, as both remote dependencies and local dependencies need to follow `<package> @ <path>` format. Even [pip documentation](https://pip.pypa.io/en/stable/reference/requirement-specifiers/) suggests to use PEP 508 format.

The usage of regexes itself definitely makes the parsing best-effort, but it could also creates some false positives, as for instance for what looks like git URLs, we try to guess where the package name is, based on the git project name in the URL, which could depend on the git server used, or, worse, the git project name could be different than the real Python package name.

This PR suggests using [packaging](https://pypi.org/project/packaging/), maintained by PyPA, to parse dependencies where we expect PEP 508 format to be used (requirements files, PEP 621 metadata). This would remove support for URLs that do not follow PEP 508 dependencies, so this is a breaking change we would have to mention in the changelog, if we effectively want to go this way.