### PR TITLE
fix(dependency_getter): avoid error on empty dependencies

### DIFF
--- a/python/deptry/dependency_getter/builder.py
+++ b/python/deptry/dependency_getter/builder.py
@@ -71,14 +71,14 @@ class DependencyGetterBuilder:
     @staticmethod
     def _project_uses_poetry(pyproject_toml: dict[str, Any]) -> bool:
         try:
-            pyproject_toml["tool"]["poetry"]["dependencies"]
+            pyproject_toml["tool"]["poetry"]
             logging.debug(
-                "pyproject.toml contains a [tool.poetry.dependencies] section, so Poetry is used to specify the"
+                "pyproject.toml contains a [tool.poetry] section, so Poetry is used to specify the"
                 " project's dependencies."
             )
         except KeyError:
             logging.debug(
-                "pyproject.toml does not contain a [tool.poetry.dependencies] section, so Poetry is not used to specify"
+                "pyproject.toml does not contain a [tool.poetry] section, so Poetry is not used to specify"
                 " the project's dependencies."
             )
             return False

--- a/python/deptry/dependency_getter/pep_621.py
+++ b/python/deptry/dependency_getter/pep_621.py
@@ -58,7 +58,7 @@ class PEP621DependencyGetter(DependencyGetter):
 
     def _get_dependencies(self) -> list[Dependency]:
         pyproject_data = load_pyproject_toml(self.config)
-        dependency_strings: list[str] = pyproject_data["project"]["dependencies"]
+        dependency_strings: list[str] = pyproject_data["project"].get("dependencies", [])
         return self._extract_pep_508_dependencies(dependency_strings, self.package_module_name_map)
 
     def _get_optional_dependencies(self) -> dict[str, list[Dependency]]:

--- a/python/deptry/dependency_getter/poetry.py
+++ b/python/deptry/dependency_getter/poetry.py
@@ -21,7 +21,7 @@ class PoetryDependencyGetter(DependencyGetter):
 
     def _get_poetry_dependencies(self) -> list[Dependency]:
         pyproject_data = load_pyproject_toml(self.config)
-        dependencies: dict[str, Any] = pyproject_data["tool"]["poetry"]["dependencies"]
+        dependencies: dict[str, Any] = pyproject_data["tool"]["poetry"].get("dependencies", {})
         return self._get_dependencies(dependencies, self.package_module_name_map)
 
     def _get_poetry_dev_dependencies(self) -> list[Dependency]:

--- a/tests/unit/dependency_getter/test_builder.py
+++ b/tests/unit/dependency_getter/test_builder.py
@@ -123,7 +123,7 @@ def test_dependency_specification_not_found_raises_exception(tmp_path: Path, cap
     assert caplog.messages == [
         "pyproject.toml found!",
         (
-            "pyproject.toml does not contain a [tool.poetry.dependencies] section, so Poetry is not used to specify the"
+            "pyproject.toml does not contain a [tool.poetry] section, so Poetry is not used to specify the"
             " project's dependencies."
         ),
         (

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -147,3 +147,20 @@ group2 = [
 
         assert dependencies[2].name == "barfoo"
         assert "barfoo" in dependencies[2].top_levels
+
+
+def test_dependency_getter_empty_dependencies(tmp_path: Path) -> None:
+    fake_pyproject_toml = """[project]
+# PEP 621 project metadata
+# See https://www.python.org/dev/peps/pep-0621/
+"""
+
+    with run_within_dir(tmp_path):
+        with Path("pyproject.toml").open("w") as f:
+            f.write(fake_pyproject_toml)
+
+        getter = PEP621DependencyGetter(config=Path("pyproject.toml"))
+        dependencies_extract = getter.get()
+
+        assert len(dependencies_extract.dependencies) == 0
+        assert len(dependencies_extract.dev_dependencies) == 0

--- a/tests/unit/dependency_getter/test_poetry.py
+++ b/tests/unit/dependency_getter/test_poetry.py
@@ -8,6 +8,9 @@ from tests.utils import run_within_dir
 
 def test_dependency_getter(tmp_path: Path) -> None:
     fake_pyproject_toml = """
+[tool.poetry]
+name = "foo"
+
 [tool.poetry.dependencies]
 python = ">=3.7,<4.0"
 bar =  { version = ">=2.5.1,<4.0.0", python = ">3.7" }
@@ -68,3 +71,20 @@ pytest-cov = "^4.0.0"
 
         assert dev_dependencies[5].name == "pytest-cov"
         assert "pytest_cov" in dev_dependencies[5].top_levels
+
+
+def test_dependency_getter_empty_dependencies(tmp_path: Path) -> None:
+    fake_pyproject_toml = """
+[tool.poetry]
+name = "foo"
+"""
+
+    with run_within_dir(tmp_path):
+        with Path("pyproject.toml").open("w") as f:
+            f.write(fake_pyproject_toml)
+
+        getter = PoetryDependencyGetter(config=Path("pyproject.toml"))
+        dependencies_extract = getter.get()
+
+        assert len(dependencies_extract.dependencies) == 0
+        assert len(dependencies_extract.dev_dependencies) == 0


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

We currently hard access `dependencies` key for both PEP 621 and Poetry projects to retrieve dependencies. Although not common, it could happen that projects use `deptry`, but do not have any production dependencies (for instance when bootstrapping a project from a minimal template, where you don't start with any dependency, but still want to include `deptry` in the CI workflow).

This PR soft accesses dependencies for both PEP 621 and Poetry. As for Poetry, we rely on `dependencies` to determine if a project uses Poetry, the logic is also updated to assume that a project uses by only checking `[tool.poetry]` instead of `[tool.poetry.dependencies]`. This should not be problematic, as `[tool.poetry]` is specific to Poetry, and Poetry only.