### PR TITLE
ci: test against PyPy on macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
     runs-on: macos-14
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
Newest macOS runners are faster (most likely because it runs on ARM). Just want to see if it also speeds up PyPy builds to an acceptable level.