### PR TITLE
chore(renovate): disable lockfile maintenance for cargo

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -37,6 +37,7 @@
   // https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
   lockFileMaintenance: {
     enabled: true,
+    enabledManagers: ["pep621"],
     schedule: ["before 5am on saturday"],
   },
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Disable lock file maintenance for cargo, as per https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-cratesio, and spotted in https://github.com/fpgmaas/deptry/pull/768/files, it can end up bumping patch/minor versions of direct dependencies.

Although this can be "ok" as long as tests pass:
- it does not play well with Renovate, for which the source of truth is `Cargo.toml`, so it ends up bumping dependencies that have already been bumped (for instance for case above: https://github.com/fpgmaas/deptry/pull/769)
- I personally prefer to read the changelog for direct dependencies before any upgrade, especially for minor versions