### PR TITLE
Support imports using `importlib.import_module`

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,8 +70,20 @@ if TYPE_CHECKING:
     import mypy_boto3_s3
 ```
 
-There is some support for imports created with `importlib`: namely any usage with a string literal
-(not where the argument is provided dynamically from a variable, attribute, etc.).
+There is some support for imports created with `importlib`: namely any usage with a string literal:
+
+```
+import importlib
+
+importlib.import_module("foo")  # package 'foo' imported
+```
+
+But not where the argument is provided dynamically from a variable, attribute, etc.
+
+```py
+bar = "foo"
+importlib.import_module(bar)  # Not detected
+```
 
 ## Excluding files and directories
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
 
 There is some support for imports created with `importlib`: namely any usage with a string literal:
 
-```
+```python
 import importlib
 
 importlib.import_module("foo")  # package 'foo' imported

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ if TYPE_CHECKING:
     import mypy_boto3_s3
 ```
 
-There is some support for imports created with `importlib`: namely any usage with a string literal:
+There is some support for imports created with [`importlib.import_module`](https://docs.python.org/3/library/importlib.html#importlib.import_module) that use a string literal:
 
 ```python
 import importlib

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,7 +78,7 @@ import importlib
 importlib.import_module("foo")  # package 'foo' imported
 ```
 
-But not where the argument is provided dynamically from a variable, attribute, etc.
+but not where the argument is provided dynamically from a variable, attribute, etc., e.g.:
 
 ```python
 bar = "foo"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ importlib.import_module("foo")  # package 'foo' imported
 
 But not where the argument is provided dynamically from a variable, attribute, etc.
 
-```py
+```python
 bar = "foo"
 importlib.import_module(bar)  # Not detected
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,9 @@ if TYPE_CHECKING:
     import mypy_boto3_s3
 ```
 
+There is some support for imports created with `importlib`: namely any usage with a string literal
+(not where the argument is provided dynamically from a variable, attribute, etc.).
+
 ## Excluding files and directories
 
 To determine issues with imported modules and dependencies, _deptry_ will scan the working directory and its subdirectories recursively for `.py` and `.ipynb` files, so it can

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -9,6 +9,13 @@ pub struct ImportVisitor {
     import_module_names: HashSet<String>,
 }
 
+/// Visitor for tracking Python imports in AST.
+///
+/// `imports`: Maps top-level module names to their import locations.
+///
+/// `import_module_names`: Tracks import names (including aliases) that
+/// refer to the `importlib.import_module` function itself, i.e. the import
+/// alias for `importlib` package and/or the `importlib.import_module` function.
 impl ImportVisitor {
     pub fn new() -> Self {
         Self {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -27,83 +27,110 @@ impl ImportVisitor {
     pub fn get_imports(self) -> HashMap<String, Vec<TextRange>> {
         self.imports
     }
+
+    /// Handles regular import statements (e.g., `import foo` or `import foo as bar`).
+    ///
+    /// Processes each name in the import statement (dealiasing if needed), and adds the
+    /// top-level module to the `imports` map.
+    ///
+    /// Imports of the `importlib` package are handled as a special case: its name (or alias),
+    /// suffixed with ".import_module", is stored in `import_module_names`. This is done to
+    /// indicate how we should look out for dynamic imports in the code that follows.
+    fn handle_import(&mut self, import_stmt: &ruff_python_ast::Import) {
+        for alias in &import_stmt.names {
+            let top_level_module = get_top_level_module_name(alias.name.as_str());
+            self.imports
+                .entry(top_level_module)
+                .or_default()
+                .push(alias.range);
+
+            if alias.name.as_str() == "importlib" {
+                let name = alias
+                    .asname
+                    .as_ref()
+                    .map(|id| id.as_str())
+                    .unwrap_or("importlib");
+                self.import_module_names
+                    .insert(format!("{}.import_module", name));
+            }
+        }
+    }
+
+    /// Handles "from" import statements (e.g., `from foo import bar` or `from foo import bar as baz`).
+    ///
+    /// Processes the module which the names are being imported from, adds it to the `imports` map
+    /// if it's a top-level import.
+    ///
+    /// Imports of `import_module` from the `importlib` package are handled as a special case: its
+    /// name (or alias), prefixed with "importlib.", is stored in `import_module_names`. This is done to
+    /// indicate how we should look out for dynamic imports in the code that follows.
+    fn handle_import_from(&mut self, import_from_stmt: &ruff_python_ast::ImportFrom) {
+        if let Some(module) = &import_from_stmt.module {
+            if import_from_stmt.level == 0 {
+                let module_name = module.as_str();
+                self.imports
+                    .entry(get_top_level_module_name(module_name))
+                    .or_default()
+                    .push(import_from_stmt.range);
+
+                if module_name == "importlib" {
+                    for alias in &import_from_stmt.names {
+                        if alias.name.as_str() == "import_module" {
+                            let name = alias
+                                .asname
+                                .as_ref()
+                                .map(|id| id.as_str())
+                                .unwrap_or("import_module");
+                            self.import_module_names.insert(name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Handles expression statements, looking for dynamic imports using `importlib.import_module`.
+    ///
+    /// This function checks if the expression is a call to a function that might be `importlib.import_module`
+    /// (which could be import aliased at either the package or function name). If so, processes the imported
+    /// module name (which must be given as a string literal, not a variable) and adds it to the `imports` map.
+    fn handle_expr(&mut self, expr_stmt: &ruff_python_ast::ExprStmt) {
+        // Check for dynamic imports using `importlib.import_module`
+        if let Expr::Call(call_expr) = expr_stmt.value.as_ref() {
+            let is_import_module = match call_expr.func.as_ref() {
+                Expr::Attribute(attr_expr) => {
+                    if let Expr::Name(name) = attr_expr.value.as_ref() {
+                        self.import_module_names
+                            .contains(&format!("{}.import_module", name.id.as_str()))
+                    } else {
+                        false
+                    }
+                }
+                Expr::Name(name) => self.import_module_names.contains(name.id.as_str()),
+                _ => false,
+            };
+
+            if is_import_module {
+                if let Some(Expr::StringLiteral(string_literal)) = call_expr.arguments.args.first()
+                {
+                    let top_level_module =
+                        get_top_level_module_name(&string_literal.value.to_string());
+                    self.imports
+                        .entry(top_level_module)
+                        .or_default()
+                        .push(expr_stmt.range);
+                }
+            }
+        }
+    }
 }
 
 impl<'a> Visitor<'a> for ImportVisitor {
     fn visit_stmt(&mut self, stmt: &'a Stmt) {
         match stmt {
-            Stmt::Import(import_stmt) => {
-                for alias in &import_stmt.names {
-                    let top_level_module = get_top_level_module_name(alias.name.as_str());
-                    self.imports
-                        .entry(top_level_module)
-                        .or_default()
-                        .push(alias.range);
-
-                    if alias.name.as_str() == "importlib" {
-                        let name = alias
-                            .asname
-                            .as_ref()
-                            .map(|id| id.as_str())
-                            .unwrap_or("importlib");
-                        self.import_module_names
-                            .insert(format!("{}.import_module", name));
-                    }
-                }
-            }
-            Stmt::ImportFrom(import_from_stmt) => {
-                if let Some(module) = &import_from_stmt.module {
-                    if import_from_stmt.level == 0 {
-                        let module_name = module.as_str();
-                        self.imports
-                            .entry(get_top_level_module_name(module_name))
-                            .or_default()
-                            .push(import_from_stmt.range);
-
-                        if module_name == "importlib" {
-                            for alias in &import_from_stmt.names {
-                                if alias.name.as_str() == "import_module" {
-                                    let name = alias
-                                        .asname
-                                        .as_ref()
-                                        .map(|id| id.as_str())
-                                        .unwrap_or("import_module");
-                                    self.import_module_names.insert(name.to_string());
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            Stmt::Expr(expr_stmt) => {
-                if let Expr::Call(call_expr) = expr_stmt.value.as_ref() {
-                    let is_import_module = match call_expr.func.as_ref() {
-                        Expr::Attribute(attr_expr) => {
-                            if let Expr::Name(name) = attr_expr.value.as_ref() {
-                                self.import_module_names
-                                    .contains(&format!("{}.import_module", name.id.as_str()))
-                            } else {
-                                false
-                            }
-                        }
-                        Expr::Name(name) => self.import_module_names.contains(name.id.as_str()),
-                        _ => false,
-                    };
-
-                    if is_import_module {
-                        if let Some(Expr::StringLiteral(string_literal)) =
-                            call_expr.arguments.args.first()
-                        {
-                            let top_level_module =
-                                get_top_level_module_name(&string_literal.value.to_string());
-                            self.imports
-                                .entry(top_level_module)
-                                .or_default()
-                                .push(expr_stmt.range);
-                        }
-                    }
-                }
-            }
+            Stmt::Import(import_stmt) => self.handle_import(import_stmt),
+            Stmt::ImportFrom(import_from_stmt) => self.handle_import_from(import_from_stmt),
+            Stmt::Expr(expr_stmt) => self.handle_expr(expr_stmt),
             Stmt::If(if_stmt) if is_guarded_by_type_checking(if_stmt) => {
                 // Avoid parsing imports that are only evaluated by type checkers.
             }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -51,10 +51,11 @@ impl<'a> Visitor<'a> for ImportVisitor {
                             for alias in &import_from_stmt.names {
                                 if alias.name.as_str() == "import_module" {
                                     self.import_module_name = Some(
-                                        alias.asname
+                                        alias
+                                            .asname
                                             .as_ref()
                                             .map(|id| id.as_str().to_string())
-                                            .unwrap_or_else(|| "import_module".to_string())
+                                            .unwrap_or_else(|| "import_module".to_string()),
                                     );
                                     break;
                                 }
@@ -76,7 +77,9 @@ impl<'a> Visitor<'a> for ImportVisitor {
                         }
                         Expr::Name(name) => {
                             // Case: import_module(...) or aliased version
-                            self.import_module_name.as_ref().map_or(false, |im_name| name.id.as_str() == im_name)
+                            self.import_module_name
+                                .as_ref()
+                                .map_or(false, |im_name| name.id.as_str() == im_name)
                         }
                         _ => false,
                     };
@@ -84,7 +87,8 @@ impl<'a> Visitor<'a> for ImportVisitor {
                     if is_import_module {
                         if let Some(arg) = call_expr.arguments.args.first() {
                             if let Expr::StringLiteral(string_literal) = arg {
-                                let top_level_module = get_top_level_module_name(&string_literal.value.to_string());
+                                let top_level_module =
+                                    get_top_level_module_name(&string_literal.value.to_string());
                                 self.imports
                                     .entry(top_level_module)
                                     .or_default()

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -85,15 +85,15 @@ impl<'a> Visitor<'a> for ImportVisitor {
                     };
 
                     if is_import_module {
-                        if let Some(arg) = call_expr.arguments.args.first() {
-                            if let Expr::StringLiteral(string_literal) = arg {
-                                let top_level_module =
-                                    get_top_level_module_name(&string_literal.value.to_string());
-                                self.imports
-                                    .entry(top_level_module)
-                                    .or_default()
-                                    .push(expr_stmt.range);
-                            }
+                        if let Some(Expr::StringLiteral(string_literal)) =
+                            call_expr.arguments.args.first()
+                        {
+                            let top_level_module =
+                                get_top_level_module_name(&string_literal.value.to_string());
+                            self.imports
+                                .entry(top_level_module)
+                                .or_default()
+                                .push(expr_stmt.range);
                         }
                     }
                 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -6,12 +6,14 @@ use std::collections::HashMap;
 #[derive(Debug, Clone)]
 pub struct ImportVisitor {
     imports: HashMap<String, Vec<TextRange>>,
+    import_module_name: Option<String>,
 }
 
 impl ImportVisitor {
     pub fn new() -> Self {
         Self {
             imports: HashMap::new(),
+            import_module_name: None,
         }
     }
 
@@ -25,20 +27,39 @@ impl<'a> Visitor<'a> for ImportVisitor {
         match stmt {
             Stmt::Import(import_stmt) => {
                 for alias in &import_stmt.names {
-                    let top_level_module = get_top_level_module_name(&alias.name);
+                    let top_level_module = get_top_level_module_name(alias.name.as_str());
                     self.imports
                         .entry(top_level_module)
                         .or_default()
                         .push(alias.range);
+
+                    if alias.name.as_str() == "importlib" {
+                        self.import_module_name = Some("import_module".to_string());
+                    }
                 }
             }
             Stmt::ImportFrom(import_from_stmt) => {
                 if let Some(module) = &import_from_stmt.module {
                     if import_from_stmt.level == 0 {
+                        let module_name = module.as_str();
                         self.imports
-                            .entry(get_top_level_module_name(module.as_str()))
+                            .entry(get_top_level_module_name(module_name))
                             .or_default()
                             .push(import_from_stmt.range);
+
+                        if module_name == "importlib" {
+                            for alias in &import_from_stmt.names {
+                                if alias.name.as_str() == "import_module" {
+                                    self.import_module_name = Some(
+                                        alias.asname
+                                            .as_ref()
+                                            .map(|id| id.as_str().to_string())
+                                            .unwrap_or_else(|| "import_module".to_string())
+                                    );
+                                    break;
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -47,18 +68,27 @@ impl<'a> Visitor<'a> for ImportVisitor {
             }
             Stmt::Expr(expr_stmt) => {
                 if let Expr::Call(call_expr) = expr_stmt.value.as_ref() {
-                    if let Expr::Attribute(attr_expr) = call_expr.func.as_ref() {
-                        if let Expr::Name(name) = attr_expr.value.as_ref() {
-                            if name.id.as_str() == "importlib" && attr_expr.attr.as_str() == "import_module" {
-                                if let Some(arg) = call_expr.arguments.args.first() {
-                                    if let Expr::StringLiteral(string_literal) = arg {
-                                        let top_level_module = get_top_level_module_name(&string_literal.value.to_string());
-                                        self.imports
-                                            .entry(top_level_module)
-                                            .or_default()
-                                            .push(expr_stmt.range);
-                                    }
-                                }
+                    let is_import_module = match call_expr.func.as_ref() {
+                        Expr::Attribute(attr_expr) => {
+                            // Case: importlib.import_module(...)
+                            matches!(attr_expr.value.as_ref(), Expr::Name(name) if name.id.as_str() == "importlib")
+                                && attr_expr.attr.as_str() == "import_module"
+                        }
+                        Expr::Name(name) => {
+                            // Case: import_module(...) or aliased version
+                            self.import_module_name.as_ref().map_or(false, |im_name| name.id.as_str() == im_name)
+                        }
+                        _ => false,
+                    };
+
+                    if is_import_module {
+                        if let Some(arg) = call_expr.arguments.args.first() {
+                            if let Expr::StringLiteral(string_literal) = arg {
+                                let top_level_module = get_top_level_module_name(&string_literal.value.to_string());
+                                self.imports
+                                    .entry(top_level_module)
+                                    .or_default()
+                                    .push(expr_stmt.range);
                             }
                         }
                     }

--- a/tests/data/some_dyn_imports.py
+++ b/tests/data/some_dyn_imports.py
@@ -1,3 +1,5 @@
 from importlib import import_module
+import importlib
 
 import_module("polars")
+importlib.import_module("patito")

--- a/tests/data/some_dyn_imports.py
+++ b/tests/data/some_dyn_imports.py
@@ -1,5 +1,7 @@
 from importlib import import_module
+from importlib import import_module as im
 import importlib
 
 import_module("polars")
 importlib.import_module("patito")
+im("uvicorn")

--- a/tests/data/some_dyn_imports.py
+++ b/tests/data/some_dyn_imports.py
@@ -1,7 +1,0 @@
-from importlib import import_module
-from importlib import import_module as im
-import importlib
-
-import_module("polars")
-importlib.import_module("patito")
-im("uvicorn")

--- a/tests/data/some_dyn_imports.py
+++ b/tests/data/some_dyn_imports.py
@@ -1,0 +1,3 @@
+from importlib import import_module
+
+import_module("polars")

--- a/tests/data/some_imports.py
+++ b/tests/data/some_imports.py
@@ -5,6 +5,7 @@ from typing import List, TYPE_CHECKING
 from importlib import import_module
 from importlib import import_module as im
 import importlib
+import importlib as il
 
 import numpy as np
 import pandas
@@ -48,3 +49,4 @@ import_module("patito")
 importlib.import_module("polars")
 im("uvicorn")
 import_module("http.server")
+il.import_module("xml.etree.ElementTree")

--- a/tests/data/some_imports.py
+++ b/tests/data/some_imports.py
@@ -44,6 +44,7 @@ class MyClass:
     def __init__(self):
         import module_in_class
 
-import_module("polars")
-importlib.import_module("patito")
+import_module("patito")
+importlib.import_module("polars")
 im("uvicorn")
+import_module("http.server")

--- a/tests/data/some_imports.py
+++ b/tests/data/some_imports.py
@@ -2,6 +2,9 @@ import typing
 from os import chdir, walk
 from pathlib import Path
 from typing import List, TYPE_CHECKING
+from importlib import import_module
+from importlib import import_module as im
+import importlib
 
 import numpy as np
 import pandas
@@ -40,3 +43,7 @@ def func():
 class MyClass:
     def __init__(self):
         import module_in_class
+
+import_module("polars")
+importlib.import_module("patito")
+im("uvicorn")

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -21,8 +21,8 @@ def test_dyn_import_parser_py() -> None:
     some_dyn_imports_path = Path("tests/data/some_dyn_imports.py")
 
     assert get_imported_modules_from_list_of_files([some_dyn_imports_path]) == {
-        "importlib": [Location(some_dyn_imports_path, line=1, column=1)]
-        "polars": [Location(some_dyn_imports_path, line=3, column=1)]
+        "importlib": [Location(some_dyn_imports_path, line=1, column=1)],
+        "polars": [Location(some_dyn_imports_path, line=3, column=1)],
     }
 
 

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -17,6 +17,15 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 
+def test_dyn_import_parser_py() -> None:
+    some_dyn_imports_path = Path("tests/data/some_dyn_imports.py")
+
+    assert get_imported_modules_from_list_of_files([some_dyn_imports_path]) == {
+        "importlib": [Location(some_dyn_imports_path, line=1, column=1)]
+        "polars": [Location(some_dyn_imports_path, line=3, column=1)]
+    }
+
+
 def test_import_parser_py() -> None:
     some_imports_path = Path("tests/data/some_imports.py")
 

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -21,8 +21,17 @@ def test_dyn_import_parser_py() -> None:
     some_dyn_imports_path = Path("tests/data/some_dyn_imports.py")
 
     assert get_imported_modules_from_list_of_files([some_dyn_imports_path]) == {
-        "importlib": [Location(some_dyn_imports_path, line=1, column=1)],
-        "polars": [Location(some_dyn_imports_path, line=3, column=1)],
+        "importlib": [
+            Location(some_dyn_imports_path, line=1, column=1),
+            Location(some_dyn_imports_path, line=2, column=1),
+            Location(some_dyn_imports_path, line=3, column=8),
+        ],
+        "patito": [
+            Location(some_dyn_imports_path, line=6, column=1),
+        ],
+        "polars": [
+            Location(some_dyn_imports_path, line=5, column=1),
+        ],
     }
 
 

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -17,44 +17,33 @@ if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
 
-def test_dyn_import_parser_py() -> None:
-    some_dyn_imports_path = Path("tests/data/some_dyn_imports.py")
-
-    assert get_imported_modules_from_list_of_files([some_dyn_imports_path]) == {
-        "importlib": [
-            Location(some_dyn_imports_path, line=1, column=1),
-            Location(some_dyn_imports_path, line=2, column=1),
-            Location(some_dyn_imports_path, line=3, column=8),
-        ],
-        "patito": [
-            Location(some_dyn_imports_path, line=6, column=1),
-        ],
-        "polars": [
-            Location(some_dyn_imports_path, line=5, column=1),
-        ],
-    }
-
-
 def test_import_parser_py() -> None:
     some_imports_path = Path("tests/data/some_imports.py")
 
     assert get_imported_modules_from_list_of_files([some_imports_path]) == {
-        "barfoo": [Location(some_imports_path, 21, 8)],
-        "baz": [Location(some_imports_path, 17, 5)],
-        "click": [Location(some_imports_path, 31, 12)],
-        "foobar": [Location(some_imports_path, 19, 12)],
-        "httpx": [Location(some_imports_path, 15, 12)],
-        "module_in_class": [Location(some_imports_path, 42, 16)],
-        "module_in_func": [Location(some_imports_path, 37, 12)],
-        "not_click": [Location(some_imports_path, 33, 12)],
+        "barfoo": [Location(some_imports_path, 24, 8)],
+        "baz": [Location(some_imports_path, 20, 5)],
+        "click": [Location(some_imports_path, 34, 12)],
+        "foobar": [Location(some_imports_path, 22, 12)],
+        "httpx": [Location(some_imports_path, 18, 12)],
+        "importlib": [
+            Location(some_imports_path, line=5, column=1),
+            Location(some_imports_path, line=6, column=1),
+            Location(some_imports_path, line=7, column=8),
+        ],
+        "module_in_class": [Location(some_imports_path, 45, 16)],
+        "module_in_func": [Location(some_imports_path, 40, 12)],
+        "not_click": [Location(some_imports_path, 36, 12)],
         "numpy": [
-            Location(some_imports_path, 6, 8),
-            Location(some_imports_path, 8, 1),
+            Location(some_imports_path, 9, 8),
+            Location(some_imports_path, 11, 1),
         ],
         "os": [Location(some_imports_path, 2, 1)],
-        "pandas": [Location(some_imports_path, 7, 8)],
+        "pandas": [Location(some_imports_path, 10, 8)],
         "pathlib": [Location(some_imports_path, 3, 1)],
-        "randomizer": [Location(some_imports_path, 22, 1)],
+        "patito": [Location(some_imports_path, line=48, column=1)],
+        "polars": [Location(some_imports_path, line=47, column=1)],
+        "randomizer": [Location(some_imports_path, 25, 1)],
         "typing": [
             Location(some_imports_path, 1, 8),
             Location(some_imports_path, 4, 1),

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -21,35 +21,37 @@ def test_import_parser_py() -> None:
     some_imports_path = Path("tests/data/some_imports.py")
 
     assert get_imported_modules_from_list_of_files([some_imports_path]) == {
-        "barfoo": [Location(some_imports_path, 24, 8)],
-        "baz": [Location(some_imports_path, 20, 5)],
-        "click": [Location(some_imports_path, 34, 12)],
-        "foobar": [Location(some_imports_path, 22, 12)],
-        "http": [Location(some_imports_path, line=50, column=1)],
-        "httpx": [Location(some_imports_path, 18, 12)],
+        "barfoo": [Location(some_imports_path, 25, 8)],
+        "baz": [Location(some_imports_path, 21, 5)],
+        "click": [Location(some_imports_path, 35, 12)],
+        "foobar": [Location(some_imports_path, 23, 12)],
+        "http": [Location(some_imports_path, line=51, column=1)],
+        "httpx": [Location(some_imports_path, 19, 12)],
         "importlib": [
             Location(some_imports_path, line=5, column=1),
             Location(some_imports_path, line=6, column=1),
             Location(some_imports_path, line=7, column=8),
+            Location(some_imports_path, line=8, column=8),
         ],
-        "module_in_class": [Location(some_imports_path, 45, 16)],
-        "module_in_func": [Location(some_imports_path, 40, 12)],
-        "not_click": [Location(some_imports_path, 36, 12)],
+        "module_in_class": [Location(some_imports_path, 46, 16)],
+        "module_in_func": [Location(some_imports_path, 41, 12)],
+        "not_click": [Location(some_imports_path, 37, 12)],
         "numpy": [
-            Location(some_imports_path, 9, 8),
-            Location(some_imports_path, 11, 1),
+            Location(some_imports_path, 10, 8),
+            Location(some_imports_path, 12, 1),
         ],
         "os": [Location(some_imports_path, 2, 1)],
-        "pandas": [Location(some_imports_path, 10, 8)],
+        "pandas": [Location(some_imports_path, 11, 8)],
         "pathlib": [Location(some_imports_path, 3, 1)],
-        "patito": [Location(some_imports_path, line=47, column=1)],
-        "polars": [Location(some_imports_path, line=48, column=1)],
-        "randomizer": [Location(some_imports_path, 25, 1)],
+        "patito": [Location(some_imports_path, line=48, column=1)],
+        "polars": [Location(some_imports_path, line=49, column=1)],
+        "randomizer": [Location(some_imports_path, 26, 1)],
         "typing": [
             Location(some_imports_path, 1, 8),
             Location(some_imports_path, 4, 1),
         ],
-        "uvicorn": [Location(some_imports_path, line=49, column=1)],
+        "uvicorn": [Location(some_imports_path, line=50, column=1)],
+        "xml": [Location(some_imports_path, line=52, column=1)],
     }
 
 

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -49,6 +49,7 @@ def test_import_parser_py() -> None:
             Location(some_imports_path, 1, 8),
             Location(some_imports_path, 4, 1),
         ],
+        "uvicorn": [Location(some_imports_path, line=49, column=1)],
     }
 
 

--- a/tests/unit/imports/test_extract.py
+++ b/tests/unit/imports/test_extract.py
@@ -25,6 +25,7 @@ def test_import_parser_py() -> None:
         "baz": [Location(some_imports_path, 20, 5)],
         "click": [Location(some_imports_path, 34, 12)],
         "foobar": [Location(some_imports_path, 22, 12)],
+        "http": [Location(some_imports_path, line=50, column=1)],
         "httpx": [Location(some_imports_path, 18, 12)],
         "importlib": [
             Location(some_imports_path, line=5, column=1),
@@ -41,8 +42,8 @@ def test_import_parser_py() -> None:
         "os": [Location(some_imports_path, 2, 1)],
         "pandas": [Location(some_imports_path, 10, 8)],
         "pathlib": [Location(some_imports_path, 3, 1)],
-        "patito": [Location(some_imports_path, line=48, column=1)],
-        "polars": [Location(some_imports_path, line=47, column=1)],
+        "patito": [Location(some_imports_path, line=47, column=1)],
+        "polars": [Location(some_imports_path, line=48, column=1)],
         "randomizer": [Location(some_imports_path, 25, 1)],
         "typing": [
             Location(some_imports_path, 1, 8),


### PR DESCRIPTION
Commits:

- test: add coverage for dynamic import with importlib
- feat(WIP): attempt to get importlib imports
- test: add test coverage for both importlib formats
- feat: also handle case where importlib.import_module is aliased
- refactor: consolidate proof of concept test into existing test
- refactor(clippy): collapse nested `if let` statements in `Stmt::Expr` match arm
- docs: note which sort of `importlib` import are supported

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

- Support for imports given as string literals directly to `importlib.import_module` 
  #780
