### PR TITLE
ci: install `cargo` before dependencies install

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -24,6 +24,10 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: true
 
+    - name: Setup Rust toolchain
+      run: rustup component add cargo clippy rustfmt
+      shell: bash
+
     - name: Install Python dependencies
       run: pdm install --frozen-lockfile --no-editable
       env:
@@ -36,7 +40,3 @@ runs:
         target: ${{ inputs.target }}
         command: develop
         sccache: 'true'
-
-    - name: Setup Rust toolchain
-      run: rustup component add clippy rustfmt
-      shell: bash

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -29,7 +29,7 @@ runs:
       shell: bash
 
     - name: Install Python dependencies
-      run: pdm install --frozen-lockfile --no-editable
+      run: pdm install --frozen-lockfile --no-editable --no-self
       env:
         PDM_VENV_WITH_PIP: "true"
       shell: bash


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

The CI has been failing quite a while lately. It seemed quite random, but the jobs that don't fail actually just retrieve cache, so by luck, they are not affected.

Debugging a bit the issue in https://github.com/fpgmaas/deptry/pull/794, spotted that the following error was returned when invoking `cargo` commands:
```console
error: the 'cargo' binary, normally provided by the 'cargo' component, is not applicable to the '1.80-x86_64-unknown-linux-gnu' toolchain
```

Explicitly adding `cargo` through `rustup` fixes that.

Also adding `--no-self` to `pdm install` because we already build the project when invoking `maturin develop`, so it's not necessary to do both.