### PR TITLE
docs: fix DEP003 example by explicitly adding certifi

### DIFF
--- a/docs/rules-violations.md
+++ b/docs/rules-violations.md
@@ -119,7 +119,7 @@ To fix the issue, `certifi` should be explicitly added to `[project.dependencies
 ```toml
 [project]
 dependencies = [
-    "httpcore==0.16.3",
+    "certifi==2024.7.4",
     "httpx==0.23.1",
 ]
 ```


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**
The example in the documentation for DEP003: transitive dependencies mentions explicitly adding `certifi` to the dependencies as the solution. 
However (and confusingly) in the toml code example the package `httpcore` is added. 
This PR makes sure the example toml code matches the written instructions by replacing `httpcore` in the example with `certifi`.


