### PR TITLE
ci: use `ubuntu-22.04` on `sdist` for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
           path: dist
 
   sdist:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [set-version]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Should fix the issue spotted in
https://github.com/fpgmaas/deptry/actions/runs/10292527780/job/28487127720 for now:
```
  error: externally-managed-environment

  × This environment is externally managed
  ╰─> To install Python packages system-wide, try apt install
      python3-xyz, where xyz is the package you are trying to
      install.
```

Need to see how to best handle this, but in the meantime, let's revert to a working workflow.