### PR TITLE
ci: use `ubuntu-22.04` on `publish` for now

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [linux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Same player shoots again (https://github.com/fpgmaas/deptry/pull/800).