### PR TITLE
ci: add ability to dry-run release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   set-version:
@@ -13,12 +14,14 @@ jobs:
       - name: Export tag
         id: vars
         run: echo tag=${GITHUB_REF#refs/*/} >> $GITHUB_OUTPUT
+        if: ${{ github.event_name == 'release' }}
 
       - name: Update project version
         run: |
           sed -i "s/^version = \".*\"/version = \"$RELEASE_VERSION\"/" pyproject.toml
         env:
           RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        if: ${{ github.event_name == 'release' }}
 
       - name: Upload updated pyproject.toml
         uses: actions/upload-artifact@v4
@@ -155,6 +158,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-22.04
     needs: [linux, windows, macos, sdist]
+    if: ${{ github.event_name == 'release' }}
     steps:
       - uses: actions/download-artifact@v4
 
@@ -169,6 +173,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-24.04
     needs: publish
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Add ability to manually trigger the release in dry-run mode (skipping upload and doc update steps). This will make it possible to test that we can build the wheels and source distribution properly before releasing, or when we do major changes to how they are built.

Tested in my fork, it works as expected (steps skipped on manual trigger, but not on real releases).