### PR TITLE
feat(cli): set max terminal width based on terminal

### DIFF
--- a/python/deptry/cli.py
+++ b/python/deptry/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 import sys
 from collections import defaultdict
 from importlib.metadata import version
@@ -240,7 +241,7 @@ def display_deptry_version(ctx: click.Context, _param: click.Parameter, value: b
     is_flag=True,
     help="Enable experimental support for namespace package (PEP 420) when detecting local modules (https://peps.python.org/pep-0420/).",
 )
-def deptry(
+def cli(
     root: tuple[Path, ...],
     config: Path,
     no_ansi: bool,
@@ -290,3 +291,9 @@ def deptry(
         pep621_dev_dependency_groups=pep621_dev_dependency_groups,
         experimental_namespace_package=experimental_namespace_package,
     ).run()
+
+
+def deptry() -> None:
+    column_size, _line_size = shutil.get_terminal_size()
+
+    cli(max_content_width=column_size)

--- a/tests/functional/cli/test_cli.py
+++ b/tests/functional/cli/test_cli.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from click.testing import CliRunner
 
-from deptry.cli import deptry
+from deptry.cli import cli
 from tests.functional.utils import Project
 from tests.utils import get_issues_report, stylize
 
@@ -625,6 +625,6 @@ def test_cli_with_json_output(poetry_venv_factory: PoetryVenvFactory) -> None:
 
 
 def test_cli_help() -> None:
-    result = CliRunner().invoke(deptry, "--help")
+    result = CliRunner().invoke(cli, "--help")
 
     assert result.exit_code == 0


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

By default, `click` wraps lines at 80 characters. This makes the command descriptions in `help` command hard to read properly IMO:

![Screenshot from 2024-08-11 01-28-14](https://github.com/user-attachments/assets/6982d3a6-f690-4f50-9ef6-ebeda83a23c2)

Per [the documentation](https://click.palletsprojects.com/en/8.1.x/documentation/#preventing-rewrapping), there is a way to change that. Using [shutil.get_terminal_size](https://docs.python.org/3/library/shutil.html#shutil.get_terminal_size) should be a sensible choice, as it will first check if the terminal provides the right information, then the OS if not, then fallback to a default `80` value (which is already what we have) if neither do.

On a full-size terminal, with a 1920x1080 screen resolution, this looks like this:

![Screenshot from 2024-08-11 01-28-48](https://github.com/user-attachments/assets/a8a64a9e-0a79-4210-81b6-94e55accfd2e)