### PR TITLE
chore(deps): bump `rust` to 1.81

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.80"
+channel = "1.81"


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html.