### PR TITLE
ci: use `ubuntu-24.04` again for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
           path: dist
 
   sdist:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [set-version]
     steps:
       - uses: actions/checkout@v4
@@ -168,7 +168,7 @@ jobs:
 
   publish:
     name: Publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [linux, windows, macos, sdist]
     if: ${{ github.event_name == 'release' }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
       - name: Download updated pyproject.toml
         uses: actions/download-artifact@v4
         with:
@@ -173,6 +178,11 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     steps:
       - uses: actions/download-artifact@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
We had to go back to `ubuntu-22.04` on https://github.com/fpgmaas/deptry/pull/800 and https://github.com/fpgmaas/deptry/pull/801. The issue was that we did not install a specific Python version, so we defaulted to the default one provided by the image, which ends up being externally managed.

Smoke-testing the release workflow in https://github.com/fpgmaas/deptry/actions/runs/10753197835/job/29822356943 and it now works as expected.