### PR TITLE
chore(renovate): remove obsolete typing deps automerge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -43,12 +43,6 @@
   // https://docs.renovatebot.com/configuration-options/#packagerules
   packageRules: [
     {
-      matchDepTypes: ["typing"],
-      matchDatasources: ["pypi"],
-      excludePackageNames: ["mypy"],
-      automerge: true,
-    },
-    {
       matchPackageNames: ["uv", "astral-sh/uv-pre-commit"],
       groupName: "uv-version",
     },


### PR DESCRIPTION
uv does not support dependency groups yet, so this rule does not do anything anymore, since there's no `typing` group.