### PR TITLE
ci: use Python 3.13 final + default to Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.os.name == 'linux' && matrix.python-version == '3.13' }}
+        if: ${{ matrix.os.name == 'linux' && matrix.python-version == env.PYTHON_VERSION }}
 
   check-docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
             image: macos-15
           - name: windows
             image: windows-2022
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13-dev', 'pypy3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10']
       fail-fast: false
     runs-on: ${{ matrix.os.image }}
     name: ${{ matrix.os.name }} (${{ matrix.python-version }})

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.13'
   # renovate: datasource=pypi depName=uv
   UV_VERSION: '0.4.18'
 
@@ -94,7 +94,7 @@ jobs:
         uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        if: ${{ matrix.os.name == 'linux' && matrix.python-version == '3.12' }}
+        if: ${{ matrix.os.name == 'linux' && matrix.python-version == '3.13' }}
 
   check-docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.13'
   # renovate: datasource=pypi depName=uv
   UV_VERSION: '0.4.18'
 
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.12', 'pypy3.10']
+        python: ['3.13', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4
@@ -75,10 +75,10 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python: ['3.12', 'pypy3.10']
+        python: ['3.13', 'pypy3.10']
         # PyPy doesn't support Windows ARM64.
         include:
-          - python: '3.12'
+          - python: '3.13'
             target: aarch64
     steps:
       - name: Check out
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.12', 'pypy3.10']
+        python: ['3.13', 'pypy3.10']
     steps:
       - name: Check out
         uses: actions/checkout@v4


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Python 3.13 final is [out](https://blog.python.org/2024/10/python-3130-final-released.html). This updates the CI to use it instead of pre-releases, and defaults jobs to 3.13 instead of 3.12.