### PR TITLE
feat: support PEP 735 dependency groups

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ To determine the project's dependencies, _deptry_ will scan the directory it is 
     - development dependencies from `[tool.uv.dev-dependencies]` section and from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
 1. If a `pyproject.toml` file with a `[project]` section is found, _deptry_ will assume it uses [PEP 621](https://peps.python.org/pep-0621/) for dependency specification and extract:
     - dependencies from `[project.dependencies]` and `[project.optional-dependencies]`.
-    - development dependencies from the groups under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
+    - development dependencies from the groups under `[dependency-groups]`, and the ones under `[project.optional-dependencies]` passed via the [`--pep621-dev-dependency-groups`](#pep-621-dev-dependency-groups) argument.
 1. If a `requirements.in` or `requirements.txt` file is found, _deptry_ will:
     - extract dependencies from that file.
     - extract development dependencies from `dev-dependencies.txt` and `dependencies-dev.txt`, if any exist

--- a/python/deptry/dependency_getter/pep621/pdm.py
+++ b/python/deptry/dependency_getter/pep621/pdm.py
@@ -18,7 +18,11 @@ class PDMDependencyGetter(PEP621DependencyGetter):
     uses PDM for its dependency management.
     """
 
-    def _get_dev_dependencies(self, dev_dependencies_from_optional: list[Dependency]) -> list[Dependency]:
+    def _get_dev_dependencies(
+        self,
+        dependency_groups_dependencies: dict[str, list[Dependency]],
+        dev_dependencies_from_optional: list[Dependency],
+    ) -> list[Dependency]:
         """
         Retrieve dev dependencies from pyproject.toml, which in PDM are specified as:
 
@@ -32,7 +36,7 @@ class PDMDependencyGetter(PEP621DependencyGetter):
             "tox-pdm>=0.5",
         ]
         """
-        dev_dependencies = super()._get_dev_dependencies(dev_dependencies_from_optional)
+        dev_dependencies = super()._get_dev_dependencies(dependency_groups_dependencies, dev_dependencies_from_optional)
 
         pyproject_data = load_pyproject_toml(self.config)
 

--- a/python/deptry/dependency_getter/pep621/uv.py
+++ b/python/deptry/dependency_getter/pep621/uv.py
@@ -18,7 +18,11 @@ class UvDependencyGetter(PEP621DependencyGetter):
     uses uv for its dependency management.
     """
 
-    def _get_dev_dependencies(self, dev_dependencies_from_optional: list[Dependency]) -> list[Dependency]:
+    def _get_dev_dependencies(
+        self,
+        dependency_groups_dependencies: dict[str, list[Dependency]],
+        dev_dependencies_from_optional: list[Dependency],
+    ) -> list[Dependency]:
         """
         Retrieve dev dependencies from pyproject.toml, which in uv are specified as:
 
@@ -31,7 +35,7 @@ class UvDependencyGetter(PEP621DependencyGetter):
 
         Dev dependencies marked as such from optional dependencies are also added to the list of dev dependencies found.
         """
-        dev_dependencies = super()._get_dev_dependencies(dev_dependencies_from_optional)
+        dev_dependencies = super()._get_dev_dependencies(dependency_groups_dependencies, dev_dependencies_from_optional)
 
         pyproject_data = load_pyproject_toml(self.config)
 

--- a/tests/data/pep_621_project/pyproject.toml
+++ b/tests/data/pep_621_project/pyproject.toml
@@ -22,6 +22,13 @@ dev = [
 test = ["pytest==7.2.0"]
 plot = ["matplotlib"]
 
+[dependency-groups]
+doc = [
+    "mkdocs==1.6.1",
+    "mkdocs-material==9.5.40",
+]
+all = [{include-group = "doc"}, "packaging==24.1"]
+
 [build-system]
 requires = ["setuptools>=61.0.0"]
 build-backend = "setuptools.build_meta"

--- a/tests/data/pep_621_project/src/main.py
+++ b/tests/data/pep_621_project/src/main.py
@@ -1,8 +1,11 @@
 from os import chdir, walk
 from pathlib import Path
 
+import asyncio
 import black
 import click
+import mkdocs
+import mkdocs_material
+import packaging
 import white as w
 from urllib3 import contrib
-import asyncio

--- a/tests/data/project_with_pdm/pyproject.toml
+++ b/tests/data/project_with_pdm/pyproject.toml
@@ -18,6 +18,13 @@ bar = ["requests>=2.28.1"]
 [tool.pdm]
 version = {source = "scm"}
 
+[dependency-groups]
+doc = [
+    "mkdocs==1.6.1",
+    "mkdocs-material==9.5.40",
+]
+all = [{include-group = "doc"}, "packaging==24.1"]
+
 [tool.pdm.dev-dependencies]
 lint = [
     "black>=22.6.0",

--- a/tests/data/project_with_pdm/src/main.py
+++ b/tests/data/project_with_pdm/src/main.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 import black
 import click
+import mkdocs
+import mkdocs_material
 import mypy
+import packaging
 import pytest
 import pytest_cov
 import white as w

--- a/tests/data/project_with_uv/pyproject.toml
+++ b/tests/data/project_with_uv/pyproject.toml
@@ -17,6 +17,13 @@ foo = [
 ]
 bar = ["requests==2.32.3"]
 
+[dependency-groups]
+doc = [
+    "mkdocs==1.6.1",
+    "mkdocs-material==9.5.40",
+]
+all = [{include-group = "doc"}, "packaging==24.1"]
+
 [tool.uv]
 dev-dependencies = [
     "black==24.8.0",

--- a/tests/data/project_with_uv/src/main.py
+++ b/tests/data/project_with_uv/src/main.py
@@ -3,7 +3,10 @@ from pathlib import Path
 
 import black
 import click
+import mkdocs
+import mkdocs_material
 import mypy
+import packaging
 import pytest
 import pytest_cov
 import white as w

--- a/tests/functional/cli/test_cli_pdm.py
+++ b/tests/functional/cli/test_cli_pdm.py
@@ -48,12 +48,48 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
             {
                 "error": {
                     "code": "DEP004",
+                    "message": "'mkdocs' imported but declared as a dev dependency",
+                },
+                "module": "mkdocs",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 6,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
+                    "message": "'mkdocs_material' imported but declared as a dev dependency",
+                },
+                "module": "mkdocs_material",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 7,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
                     "message": "'mypy' imported but declared as a dev dependency",
                 },
                 "module": "mypy",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 6,
+                    "line": 8,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
+                    "message": "'packaging' imported but declared as a dev dependency",
+                },
+                "module": "packaging",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 9,
                     "column": 8,
                 },
             },
@@ -65,7 +101,7 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
                 "module": "pytest",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 7,
+                    "line": 10,
                     "column": 8,
                 },
             },
@@ -77,7 +113,7 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
                 "module": "pytest_cov",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 8,
+                    "line": 11,
                     "column": 8,
                 },
             },
@@ -89,7 +125,7 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
                 "module": "white",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 9,
+                    "line": 12,
                     "column": 8,
                 },
             },

--- a/tests/functional/cli/test_cli_pep_621.py
+++ b/tests/functional/cli/test_cli_pep_621.py
@@ -58,11 +58,26 @@ def test_cli_with_pep_621(pip_venv_factory: PipVenvFactory) -> None:
             {
                 "error": {"code": "DEP004", "message": "'black' imported but declared as a dev dependency"},
                 "module": "black",
-                "location": {"file": str(Path("src/main.py")), "line": 4, "column": 8},
+                "location": {"file": str(Path("src/main.py")), "line": 5, "column": 8},
+            },
+            {
+                "error": {"code": "DEP004", "message": "'mkdocs' imported but declared as a dev dependency"},
+                "module": "mkdocs",
+                "location": {"file": str(Path("src/main.py")), "line": 7, "column": 8},
+            },
+            {
+                "error": {"code": "DEP004", "message": "'mkdocs_material' imported but declared as a dev dependency"},
+                "module": "mkdocs_material",
+                "location": {"file": str(Path("src/main.py")), "line": 8, "column": 8},
+            },
+            {
+                "error": {"code": "DEP004", "message": "'packaging' imported but declared as a dev dependency"},
+                "module": "packaging",
+                "location": {"file": str(Path("src/main.py")), "line": 9, "column": 8},
             },
             {
                 "error": {"code": "DEP001", "message": "'white' imported but missing from the dependency definitions"},
                 "module": "white",
-                "location": {"file": str(Path("src/main.py")), "line": 6, "column": 8},
+                "location": {"file": str(Path("src/main.py")), "line": 10, "column": 8},
             },
         ]

--- a/tests/functional/cli/test_cli_uv.py
+++ b/tests/functional/cli/test_cli_uv.py
@@ -48,12 +48,48 @@ def test_cli_with_uv(uv_venv_factory: UvVenvFactory) -> None:
             {
                 "error": {
                     "code": "DEP004",
+                    "message": "'mkdocs' imported but declared as a dev dependency",
+                },
+                "module": "mkdocs",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 6,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
+                    "message": "'mkdocs_material' imported but declared as a dev dependency",
+                },
+                "module": "mkdocs_material",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 7,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
                     "message": "'mypy' imported but declared as a dev dependency",
                 },
                 "module": "mypy",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 6,
+                    "line": 8,
+                    "column": 8,
+                },
+            },
+            {
+                "error": {
+                    "code": "DEP004",
+                    "message": "'packaging' imported but declared as a dev dependency",
+                },
+                "module": "packaging",
+                "location": {
+                    "file": str(Path("src/main.py")),
+                    "line": 9,
                     "column": 8,
                 },
             },
@@ -65,7 +101,7 @@ def test_cli_with_uv(uv_venv_factory: UvVenvFactory) -> None:
                 "module": "pytest",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 7,
+                    "line": 10,
                     "column": 8,
                 },
             },
@@ -77,7 +113,7 @@ def test_cli_with_uv(uv_venv_factory: UvVenvFactory) -> None:
                 "module": "pytest_cov",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 8,
+                    "line": 11,
                     "column": 8,
                 },
             },
@@ -89,7 +125,7 @@ def test_cli_with_uv(uv_venv_factory: UvVenvFactory) -> None:
                 "module": "white",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 9,
+                    "line": 12,
                     "column": 8,
                 },
             },

--- a/tests/unit/dependency_getter/test_pdm.py
+++ b/tests/unit/dependency_getter/test_pdm.py
@@ -19,14 +19,16 @@ dependencies = [
     "fox-python",  # top level module is called "fox"
 ]
 
+[dependency-groups]
+dev-group = ["foo", "baz"]
+all = [{include-group = "dev-group"}, "foobaz"]
+
 [tool.pdm.dev-dependencies]
 test = [
     "qux",
     "bar; python_version < 3.11"
 ]
-tox = [
-    "foo-bar",
-]
+tox = ["foo-bar"]
 """
 
     with run_within_dir(tmp_path):
@@ -42,6 +44,7 @@ tox = [
         dev_dependencies = dependencies_extract.dev_dependencies
 
         assert len(dependencies) == 5
+        assert len(dev_dependencies) == 6
 
         assert dependencies[0].name == "qux"
         assert "qux" in dependencies[0].top_levels
@@ -58,13 +61,20 @@ tox = [
         assert dependencies[4].name == "fox-python"
         assert "fox" in dependencies[4].top_levels
 
-        assert len(dev_dependencies) == 3
+        assert dev_dependencies[0].name == "foo"
+        assert "foo" in dev_dependencies[0].top_levels
 
-        assert dev_dependencies[0].name == "qux"
-        assert "qux" in dev_dependencies[0].top_levels
+        assert dev_dependencies[1].name == "baz"
+        assert "baz" in dev_dependencies[1].top_levels
 
-        assert dev_dependencies[1].name == "bar"
-        assert "bar" in dev_dependencies[1].top_levels
+        assert dev_dependencies[2].name == "foobaz"
+        assert "foobaz" in dev_dependencies[2].top_levels
 
-        assert dev_dependencies[2].name == "foo-bar"
-        assert "foo_bar" in dev_dependencies[2].top_levels
+        assert dev_dependencies[3].name == "qux"
+        assert "qux" in dev_dependencies[3].top_levels
+
+        assert dev_dependencies[4].name == "bar"
+        assert "bar" in dev_dependencies[4].top_levels
+
+        assert dev_dependencies[5].name == "foo-bar"
+        assert "foo_bar" in dev_dependencies[5].top_levels

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -74,17 +74,15 @@ def test_dependency_getter_with_dev_dependencies(tmp_path: Path) -> None:
     fake_pyproject_toml = """[project]
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
-dependencies = [
-"qux",
-]
+dependencies = ["qux"]
 
 [project.optional-dependencies]
-group1 = [
-    "foobar",
-]
-group2 = [
-    "barfoo",
-]
+group1 = ["foobar"]
+group2 = ["barfoo"]
+
+[dependency-groups]
+dev-group = ["foo", "baz"]
+all = [{include-group = "dev-group"}, "foobaz"]
 """
 
     with run_within_dir(tmp_path):
@@ -96,6 +94,7 @@ group2 = [
         dev_dependencies = getter.get().dev_dependencies
 
         assert len(dependencies) == 2
+        assert len(dev_dependencies) == 4
 
         assert dependencies[0].name == "qux"
         assert "qux" in dependencies[0].top_levels
@@ -103,26 +102,28 @@ group2 = [
         assert dependencies[1].name == "foobar"
         assert "foobar" in dependencies[1].top_levels
 
-        assert len(dev_dependencies) == 1
-        assert dev_dependencies[0].name == "barfoo"
-        assert "barfoo" in dev_dependencies[0].top_levels
+        assert dev_dependencies[0].name == "foo"
+        assert "foo" in dev_dependencies[0].top_levels
+
+        assert dev_dependencies[1].name == "baz"
+        assert "baz" in dev_dependencies[1].top_levels
+
+        assert dev_dependencies[2].name == "foobaz"
+        assert "foobaz" in dev_dependencies[2].top_levels
+
+        assert dev_dependencies[3].name == "barfoo"
+        assert "barfoo" in dev_dependencies[3].top_levels
 
 
 def test_dependency_getter_with_incorrect_dev_group(tmp_path: Path, caplog: LogCaptureFixture) -> None:
     fake_pyproject_toml = """[project]
 # PEP 621 project metadata
 # See https://www.python.org/dev/peps/pep-0621/
-dependencies = [
-"qux",
-]
+dependencies = ["qux"]
 
 [project.optional-dependencies]
-group1 = [
-    "foobar",
-]
-group2 = [
-    "barfoo",
-]
+group1 = ["foobar"]
+group2 = ["barfoo"]
 """
 
     with run_within_dir(tmp_path), caplog.at_level(logging.INFO):

--- a/tests/unit/dependency_getter/test_uv.py
+++ b/tests/unit/dependency_getter/test_uv.py
@@ -19,6 +19,10 @@ dependencies = [
     "fox-python",  # top level module is called "fox"
 ]
 
+[dependency-groups]
+dev-group = ["foo", "baz"]
+all = [{include-group = "dev-group"}, "foobaz"]
+
 [tool.uv]
 dev-dependencies = [
     "qux",
@@ -40,6 +44,7 @@ dev-dependencies = [
         dev_dependencies = dependencies_extract.dev_dependencies
 
         assert len(dependencies) == 5
+        assert len(dev_dependencies) == 6
 
         assert dependencies[0].name == "qux"
         assert "qux" in dependencies[0].top_levels
@@ -56,13 +61,20 @@ dev-dependencies = [
         assert dependencies[4].name == "fox-python"
         assert "fox" in dependencies[4].top_levels
 
-        assert len(dev_dependencies) == 3
+        assert dev_dependencies[0].name == "foo"
+        assert "foo" in dev_dependencies[0].top_levels
 
-        assert dev_dependencies[0].name == "qux"
-        assert "qux" in dev_dependencies[0].top_levels
+        assert dev_dependencies[1].name == "baz"
+        assert "baz" in dev_dependencies[1].top_levels
 
-        assert dev_dependencies[1].name == "bar"
-        assert "bar" in dev_dependencies[1].top_levels
+        assert dev_dependencies[2].name == "foobaz"
+        assert "foobaz" in dev_dependencies[2].top_levels
 
-        assert dev_dependencies[2].name == "foo-bar"
-        assert "foo_bar" in dev_dependencies[2].top_levels
+        assert dev_dependencies[3].name == "qux"
+        assert "qux" in dev_dependencies[3].top_levels
+
+        assert dev_dependencies[4].name == "bar"
+        assert "bar" in dev_dependencies[4].top_levels
+
+        assert dev_dependencies[5].name == "foo-bar"
+        assert "foo_bar" in dev_dependencies[5].top_levels


### PR DESCRIPTION
Closes #885.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Add support for [PEP 735](https://peps.python.org/pep-0735/) dependency groups. Assuming for now that all groups are developments ones, but we might want to make that configurable, following what is described in the issue. Since the PEP is quite new, and not even implemented in any package manager yet, I'd prefer to leave that aside for now, and see if the need to define some dependency groups as non-dev ones is something we need to add support for at some point.

Note that for now, AFAIK none of the PEP 621-compliant package managers support PEP 735 yet, but the PR still by default assumes that they do. Several reason for that:

- I believe most package managers will eventually support PEP 735
- Users of a package manager that doesn't yet support PEP 735 will probably not add a `[dependency-groups]` section in their `pyproject.toml`
- ... and even if they do, worst case is that we'll flag some dependencies as dev ones where we shouldn't, which is I believe less problematic than incorrectly flagging some dependencies as production ones]
- Even on our design, we consider PEP 621 dependency getter, and have some specific parsing for popular package managers supporting PEP 621, so we have a hand on uv and PDM, but other package managers support PEP 621 exist, and for them, we would not have any control on whereas `[dependency-groups]` is supported or not anyway, until we implement specific extension support for them