### PR TITLE
chore(deps): bump `rust` to 1.82

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81"
+channel = "1.82"


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html.