### PR TITLE
chore: use `dependency-groups`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install Python dependencies
-        run: uv sync --frozen --no-install-project
+        run: uv sync --frozen
 
       - name: Setup Rust toolchain
         run: rustup component add clippy rustfmt
@@ -78,7 +78,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --group test --group typing
 
       - name: Check typing
         run: uv run mypy
@@ -111,11 +111,5 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Install Python dependencies
-        run: uv sync --frozen --no-install-project
-
       - name: Check if documentation can be built
-        # `--no-project` is a workaround to avoid the installation of deptry
-        # itself (https://github.com/astral-sh/uv/issues/6578)
-        run: uv run --no-project mkdocs build --strict
+        run: uv run --only-group docs mkdocs build --strict

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,10 +210,5 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Install Python dependencies
-        run: uv sync --frozen --no-install-project
-
       - name: Deploy documentation
-        # `--no-project` is a workaround to avoid the installation of deptry
-        # itself (https://github.com/astral-sh/uv/issues/6578)
-        run: uv run --no-project mkdocs gh-deploy --force
+        run: uv run --only-group docs mkdocs gh-deploy --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,16 +30,20 @@ dependencies = [
     "tomli>=2.0.1; python_version < '3.11'",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+docs = [
     "mkdocs==1.6.1",
     "mkdocs-material==9.5.42",
-    "mypy[faster-cache]==1.13.0; implementation_name == 'cpython'",
-    # orjson does not compile on PyPy.
-    "mypy==1.13.0; implementation_name != 'cpython'",
+]
+test = [
     "pytest==8.3.3",
     "pytest-cov==5.0.0",
     "pytest-xdist[psutil]==3.6.1",
+]
+typing = [
+    "mypy[faster-cache]==1.13.0; implementation_name == 'cpython'",
+    # orjson does not compile on PyPy.
+    "mypy==1.13.0; implementation_name != 'cpython'",
     "types-colorama==0.4.15.20240311; sys_platform == 'win32'",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -214,14 +214,18 @@ dependencies = [
 ]
 
 [package.dependency-groups]
-dev = [
+docs = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
-    { name = "mypy" },
-    { name = "mypy", extra = ["faster-cache"], marker = "implementation_name == 'cpython'" },
+]
+test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist", extra = ["psutil"] },
+]
+typing = [
+    { name = "mypy" },
+    { name = "mypy", extra = ["faster-cache"], marker = "implementation_name == 'cpython'" },
     { name = "types-colorama", marker = "sys_platform == 'win32'" },
 ]
 
@@ -234,14 +238,18 @@ requires-dist = [
 ]
 
 [package.metadata.dependency-groups]
-dev = [
+docs = [
     { name = "mkdocs", specifier = "==1.6.1" },
     { name = "mkdocs-material", specifier = "==9.5.42" },
-    { name = "mypy", marker = "implementation_name != 'cpython'", specifier = "==1.13.0" },
-    { name = "mypy", extras = ["faster-cache"], marker = "implementation_name == 'cpython'", specifier = "==1.13.0" },
+]
+test = [
     { name = "pytest", specifier = "==8.3.3" },
     { name = "pytest-cov", specifier = "==5.0.0" },
     { name = "pytest-xdist", extras = ["psutil"], specifier = "==3.6.1" },
+]
+typing = [
+    { name = "mypy", marker = "implementation_name != 'cpython'", specifier = "==1.13.0" },
+    { name = "mypy", extras = ["faster-cache"], marker = "implementation_name == 'cpython'", specifier = "==1.13.0" },
     { name = "types-colorama", marker = "sys_platform == 'win32'", specifier = "==0.4.15.20240311" },
 ]
 


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

uv now supports [`dependency-groups`](https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups), so we can switch to it. Support in Renovate was also recently added (https://docs.renovatebot.com/modules/manager/pep621/#additional-information), so we won't lose dependency updates.