### PR TITLE
test(violations): correctly test DEP003

### DIFF
--- a/tests/unit/violations/dep003_transitive/test_finder.py
+++ b/tests/unit/violations/dep003_transitive/test_finder.py
@@ -1,57 +1,56 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 from deptry.imports.location import Location
 from deptry.module import ModuleBuilder, ModuleLocations
 from deptry.violations import DEP003TransitiveDependenciesFinder
 from deptry.violations.dep003_transitive.violation import DEP003TransitiveDependencyViolation
 
-if TYPE_CHECKING:
-    from deptry.dependency import Dependency
-
 
 def test_simple() -> None:
-    """
-    black is in testing environment which requires platformdirs, so platformdirs should be found as transitive.
-    """
-    dependencies: list[Dependency] = []
+    module = ModuleBuilder("foo", set(), frozenset()).build()
 
-    module_platformdirs_locations = [Location(Path("foo.py"), 1, 2), Location(Path("bar.py"), 3, 4)]
-    module_platformdirs = ModuleBuilder("platformdirs", {"foo"}, frozenset(), dependencies).build()
+    with patch.object(module, "package", return_value="foo"):
+        issues = DEP003TransitiveDependenciesFinder(
+            [ModuleLocations(module, [Location(Path("foo.py"), 1, 2)])],
+            [],
+            frozenset(),
+        ).find()
 
-    modules_locations = [ModuleLocations(module_platformdirs, module_platformdirs_locations)]
-
-    assert DEP003TransitiveDependenciesFinder(modules_locations, dependencies, frozenset()).find() == [
-        DEP003TransitiveDependencyViolation(module_platformdirs, location) for location in module_platformdirs_locations
+    assert issues == [
+        DEP003TransitiveDependencyViolation(
+            issue=module,
+            location=Location(
+                file=Path("foo.py"),
+                line=1,
+                column=2,
+            ),
+        ),
     ]
 
 
 def test_simple_with_ignore() -> None:
-    dependencies: list[Dependency] = []
-    modules_locations = [
-        ModuleLocations(
-            ModuleBuilder("foobar", {"foo"}, frozenset(), dependencies).build(), [Location(Path("foo.py"), 1, 2)]
-        )
-    ]
+    module = ModuleBuilder("foo", set(), frozenset()).build()
 
-    assert (
-        DEP003TransitiveDependenciesFinder(
-            modules_locations, dependencies, frozenset(), ignored_modules=("foobar",)
+    with patch.object(module, "package", return_value="foo"):
+        issues = DEP003TransitiveDependenciesFinder(
+            [ModuleLocations(module, [Location(Path("foo.py"), 1, 2)])],
+            [],
+            frozenset(),
+            ignored_modules=("foo",),
         ).find()
-        == []
-    )
+
+    assert issues == []
 
 
 def test_simple_with_standard_library() -> None:
-    dependencies: list[Dependency] = []
-    standard_library_modules = frozenset(["foobar"])
-    modules_locations = [
-        ModuleLocations(
-            ModuleBuilder("foobar", {"foo"}, standard_library_modules, dependencies).build(),
-            [Location(Path("foo.py"), 1, 2)],
-        )
-    ]
+    module = ModuleBuilder("foo", set(), standard_library_modules=frozenset(["foo"])).build()
 
-    assert DEP003TransitiveDependenciesFinder(modules_locations, dependencies, frozenset()).find() == []
+    with patch.object(module, "package", return_value="foo"):
+        issues = DEP003TransitiveDependenciesFinder(
+            [ModuleLocations(module, [Location(Path("foo.py"), 1, 2)])], [], frozenset()
+        ).find()
+
+    assert issues == []


### PR DESCRIPTION
Spotted in https://github.com/fpgmaas/deptry/actions/runs/11560721483/job/32178177873 that those tests depend on packages that deptry itself depends on, which is not great. Explicitly mocking `package` avoids that.