### PR TITLE
feat(pep621): use `packaging`-based PEP 508 parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 dependencies = [
     "click>=8.0.0,<9",
     "colorama>=0.4.6; sys_platform == 'win32'",
+    "packaging>=23.2",
     "requirements-parser>=0.11.0,<1",
     "tomli>=2.0.1; python_version < '3.11'",
 ]

--- a/python/deptry/dependency.py
+++ b/python/deptry/dependency.py
@@ -6,8 +6,10 @@ from contextlib import suppress
 from importlib import metadata
 from typing import TYPE_CHECKING
 
+from packaging.requirements import InvalidRequirement, Requirement
+
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Mapping, Sequence
     from importlib.metadata import Distribution
     from pathlib import Path
 
@@ -132,3 +134,18 @@ class Dependency:
         matches = re.finditer(r"^(?!__)([a-zA-Z0-9-_]+)(?:/|\.py,)", metadata_records, re.MULTILINE)
 
         return {x.group(1) for x in matches}
+
+
+def parse_pep_508_dependency(
+    specification: str, definition_file: Path, package_module_name_map: Mapping[str, Sequence[str]]
+) -> Dependency | None:
+    try:
+        requirement = Requirement(specification)
+    except InvalidRequirement:
+        return None
+
+    return Dependency(
+        name=requirement.name,
+        definition_file=definition_file,
+        module_names=package_module_name_map.get(requirement.name),
+    )

--- a/tests/unit/dependency_getter/test_pdm.py
+++ b/tests/unit/dependency_getter/test_pdm.py
@@ -15,7 +15,7 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
     "fox-python",  # top level module is called "fox"
 ]
 
@@ -26,7 +26,7 @@ all = [{include-group = "dev-group"}, "foobaz"]
 [tool.pdm.dev-dependencies]
 test = [
     "qux",
-    "bar; python_version < 3.11"
+    "bar; python_version < '3.11'"
 ]
 tox = ["foo-bar"]
 """

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -19,7 +19,7 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
     "fox-python",  # top level module is called "fox"
 ]
 

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -13,8 +13,7 @@ if TYPE_CHECKING:
 
 def test_dependency_getter(tmp_path: Path) -> None:
     fake_pyproject_toml = """[project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dependencies = [
     "qux",
     "bar>=20.9",
@@ -72,8 +71,7 @@ group2 = [
 
 def test_dependency_getter_with_dev_dependencies(tmp_path: Path) -> None:
     fake_pyproject_toml = """[project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dependencies = ["qux"]
 
 [project.optional-dependencies]
@@ -117,8 +115,7 @@ all = [{include-group = "dev-group"}, "foobaz"]
 
 def test_dependency_getter_with_incorrect_dev_group(tmp_path: Path, caplog: LogCaptureFixture) -> None:
     fake_pyproject_toml = """[project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dependencies = ["qux"]
 
 [project.optional-dependencies]
@@ -152,8 +149,7 @@ group2 = ["barfoo"]
 
 def test_dependency_getter_empty_dependencies(tmp_path: Path) -> None:
     fake_pyproject_toml = """[project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 """
 
     with run_within_dir(tmp_path):
@@ -167,14 +163,40 @@ def test_dependency_getter_empty_dependencies(tmp_path: Path) -> None:
         assert len(dependencies_extract.dev_dependencies) == 0
 
 
+def test_dependency_getter_invalid_dependencies(tmp_path: Path) -> None:
+    """Test that invalid dependencies are skipped, but valid dependencies are still parsed."""
+    fake_pyproject_toml = """[project]
+name = "foo"
+dependencies = [
+    "qux",
+    # Invalid dependency, as the dependency marker does not exist.
+    "foo-bar>=1.1.0; java_version < '3.11'",
+    "bar>=20.9",
+]
+"""
+
+    with run_within_dir(tmp_path):
+        with Path("pyproject.toml").open("w") as f:
+            f.write(fake_pyproject_toml)
+
+        dependencies = PEP621DependencyGetter(config=Path("pyproject.toml")).get().dependencies
+
+        assert len(dependencies) == 2
+
+        assert dependencies[0].name == "qux"
+        assert "qux" in dependencies[0].top_levels
+
+        assert dependencies[1].name == "bar"
+        assert "bar" in dependencies[1].top_levels
+
+
 def test_dependency_getter_with_setuptools_dynamic_dependencies(tmp_path: Path) -> None:
     fake_pyproject_toml = """[build-system]
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools.dynamic]
@@ -216,8 +238,7 @@ dev = { file = ["dev-requirements.txt"] }
 
 def test_dependency_getter_with_setuptools_dynamic_dependencies_without_build_backend(tmp_path: Path) -> None:
     fake_pyproject_toml = """[project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools.dynamic]
@@ -258,8 +279,7 @@ requires = ["pdm-backend"]
 build-backend = "pdm.backend"
 
 [project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools.dynamic]
@@ -300,8 +320,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project]
-# PEP 621 project metadata
-# See https://www.python.org/dev/peps/pep-0621/
+name = "foo"
 dependencies = ["foo==1.2.3"]
 dynamic = ["optional-dependencies"]
 

--- a/tests/unit/dependency_getter/test_uv.py
+++ b/tests/unit/dependency_getter/test_uv.py
@@ -15,7 +15,7 @@ dependencies = [
     "qux",
     "bar>=20.9",
     "optional-foo[option]>=0.12.11",
-    "conditional-bar>=1.1.0; python_version < 3.11",
+    "conditional-bar>=1.1.0; python_version < '3.11'",
     "fox-python",  # top level module is called "fox"
 ]
 
@@ -26,7 +26,7 @@ all = [{include-group = "dev-group"}, "foobaz"]
 [tool.uv]
 dev-dependencies = [
     "qux",
-    "bar; python_version < 3.11",
+    "bar; python_version < '3.11'",
     "foo-bar",
 ]
 """

--- a/tests/unit/test_dependency.py
+++ b/tests/unit/test_dependency.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
-from deptry.dependency import Dependency
+import pytest
+
+from deptry.dependency import Dependency, parse_pep_508_dependency
 
 
 def test_simple_dependency() -> None:
@@ -99,3 +102,46 @@ def test_not_predefined_and_not_installed() -> None:
 
     assert dependency.name == "Foo-bar"
     assert dependency.top_levels == {"foo_bar"}
+
+
+@pytest.mark.parametrize(
+    ("specification", "definition_file", "package_module_name_map", "expected"),
+    [
+        (
+            "foo",
+            Path("pyproject.toml"),
+            {},
+            {
+                "name": "foo",
+                "definition_file": Path("pyproject.toml"),
+                "found": False,
+                "top_levels": {"foo"},
+            },
+        ),
+        (
+            'foobar[extra]==1.2.3; python_version < "3.9"',
+            Path("requirements.txt"),
+            {"foobar": ["foo"], "barfoo": ["bar"]},
+            {
+                "name": "foobar",
+                "definition_file": Path("requirements.txt"),
+                "found": False,
+                "top_levels": {"foo"},
+            },
+        ),
+    ],
+)
+def test_parse_pep_508_dependency(
+    specification: str,
+    definition_file: Path,
+    package_module_name_map: dict[str, list[str]],
+    expected: dict[str, Any],
+) -> None:
+    dependency = parse_pep_508_dependency(specification, definition_file, package_module_name_map)
+
+    for dependency_key, expected_value in expected.items():
+        assert getattr(dependency, dependency_key) == expected_value
+
+
+def test_parse_pep_508_dependency_invalid_definition() -> None:
+    assert parse_pep_508_dependency("an_incorrect_definition=1.2.3", Path("pyproject.toml"), {}) is None

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,7 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
     { name = "requirements-parser" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -233,6 +234,7 @@ typing = [
 requires-dist = [
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "colorama", marker = "sys_platform == 'win32'", specifier = ">=0.4.6" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "requirements-parser", specifier = ">=0.11.0,<1" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]


### PR DESCRIPTION
Closes #735.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

In https://github.com/fpgmaas/deptry/pull/913, we've changed the way we parse dependencies from requirements by switching to `requirements-parser`. This partly replaces what was done in https://github.com/fpgmaas/deptry/pull/735.

Since the dependency we added itself depends on `packaging`, we can leverage it to parse dependencies defined in PEP 621, without adding a new dependency.