### PR TITLE
test(functional): remove dependency over `mkdocs`

### DIFF
--- a/tests/fixtures/pep_621_project/pyproject.toml
+++ b/tests/fixtures/pep_621_project/pyproject.toml
@@ -21,11 +21,11 @@ test = ["pytest==8.3.3"]
 plot = ["matplotlib==3.9.2"]
 
 [dependency-groups]
-doc = [
-    "mkdocs==1.6.1",
-    "mkdocs-material==9.5.42",
+foo = [
+    "certifi==2024.8.30",
+    "idna==3.10",
 ]
-all = [{include-group = "doc"}, "packaging==24.1"]
+all = [{include-group = "foo"}, "packaging==24.1"]
 
 [build-system]
 requires = ["setuptools>=61.0.0"]

--- a/tests/fixtures/pep_621_project/src/main.py
+++ b/tests/fixtures/pep_621_project/src/main.py
@@ -3,9 +3,9 @@ from pathlib import Path
 
 import asyncio
 import black
+import certifi
 import click
-import mkdocs
-import mkdocs_material
+import idna
 import packaging
 import white as w
 from urllib3 import contrib

--- a/tests/fixtures/project_with_pdm/pyproject.toml
+++ b/tests/fixtures/project_with_pdm/pyproject.toml
@@ -19,11 +19,11 @@ bar = ["requests==2.32.3"]
 version = {source = "scm"}
 
 [dependency-groups]
-doc = [
-    "mkdocs==1.6.1",
-    "mkdocs-material==9.5.42",
+foo = [
+    "certifi==2024.8.30",
+    "idna==3.10",
 ]
-all = [{include-group = "doc"}, "packaging==24.1"]
+all = [{include-group = "foo"}, "packaging==24.1"]
 
 [tool.pdm.dev-dependencies]
 lint = [

--- a/tests/fixtures/project_with_pdm/src/main.py
+++ b/tests/fixtures/project_with_pdm/src/main.py
@@ -2,9 +2,9 @@ from os import chdir, walk
 from pathlib import Path
 
 import black
+import certifi
 import click
-import mkdocs
-import mkdocs_material
+import idna
 import mypy
 import packaging
 import pytest

--- a/tests/fixtures/project_with_uv/pyproject.toml
+++ b/tests/fixtures/project_with_uv/pyproject.toml
@@ -16,11 +16,11 @@ foo = [
 bar = ["requests==2.32.3"]
 
 [dependency-groups]
-doc = [
-    "mkdocs==1.6.1",
-    "mkdocs-material==9.5.42",
+foo = [
+    "certifi==2024.8.30",
+    "idna==3.10",
 ]
-all = [{include-group = "doc"}, "packaging==24.1"]
+all = [{include-group = "foo"}, "packaging==24.1"]
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/fixtures/project_with_uv/src/main.py
+++ b/tests/fixtures/project_with_uv/src/main.py
@@ -2,9 +2,9 @@ from os import chdir, walk
 from pathlib import Path
 
 import black
+import certifi
 import click
-import mkdocs
-import mkdocs_material
+import idna
 import mypy
 import packaging
 import pytest

--- a/tests/functional/cli/test_cli_pdm.py
+++ b/tests/functional/cli/test_cli_pdm.py
@@ -48,21 +48,21 @@ def test_cli_with_pdm(pdm_venv_factory: PDMVenvFactory) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "'mkdocs' imported but declared as a dev dependency",
+                    "message": "'certifi' imported but declared as a dev dependency",
                 },
-                "module": "mkdocs",
+                "module": "certifi",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 6,
+                    "line": 5,
                     "column": 8,
                 },
             },
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "'mkdocs_material' imported but declared as a dev dependency",
+                    "message": "'idna' imported but declared as a dev dependency",
                 },
-                "module": "mkdocs_material",
+                "module": "idna",
                 "location": {
                     "file": str(Path("src/main.py")),
                     "line": 7,

--- a/tests/functional/cli/test_cli_pep_621.py
+++ b/tests/functional/cli/test_cli_pep_621.py
@@ -61,13 +61,13 @@ def test_cli_with_pep_621(pip_venv_factory: PipVenvFactory) -> None:
                 "location": {"file": str(Path("src/main.py")), "line": 5, "column": 8},
             },
             {
-                "error": {"code": "DEP004", "message": "'mkdocs' imported but declared as a dev dependency"},
-                "module": "mkdocs",
-                "location": {"file": str(Path("src/main.py")), "line": 7, "column": 8},
+                "error": {"code": "DEP004", "message": "'certifi' imported but declared as a dev dependency"},
+                "module": "certifi",
+                "location": {"file": str(Path("src/main.py")), "line": 6, "column": 8},
             },
             {
-                "error": {"code": "DEP004", "message": "'mkdocs_material' imported but declared as a dev dependency"},
-                "module": "mkdocs_material",
+                "error": {"code": "DEP004", "message": "'idna' imported but declared as a dev dependency"},
+                "module": "idna",
                 "location": {"file": str(Path("src/main.py")), "line": 8, "column": 8},
             },
             {

--- a/tests/functional/cli/test_cli_uv.py
+++ b/tests/functional/cli/test_cli_uv.py
@@ -48,21 +48,21 @@ def test_cli_with_uv(uv_venv_factory: UvVenvFactory) -> None:
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "'mkdocs' imported but declared as a dev dependency",
+                    "message": "'certifi' imported but declared as a dev dependency",
                 },
-                "module": "mkdocs",
+                "module": "certifi",
                 "location": {
                     "file": str(Path("src/main.py")),
-                    "line": 6,
+                    "line": 5,
                     "column": 8,
                 },
             },
             {
                 "error": {
                     "code": "DEP004",
-                    "message": "'mkdocs_material' imported but declared as a dev dependency",
+                    "message": "'idna' imported but declared as a dev dependency",
                 },
-                "module": "mkdocs_material",
+                "module": "idna",
                 "location": {
                     "file": str(Path("src/main.py")),
                     "line": 7,


### PR DESCRIPTION
Did some debugging in https://github.com/fpgmaas/deptry/pull/934 to investigate slowness on Windows PyPy tests, and for some reason running PDM tests take about 10 minutes. Removing dependency over `mkdocs` seems to solve the slowness. Although we don't notice the same slowness, doing the same on other tests for consistency.