### PR TITLE
fix(dependency_getter): handle strings for `setuptools` dynamic dependencies

### DIFF
--- a/python/deptry/dependency_getter/pep621/base.py
+++ b/python/deptry/dependency_getter/pep621/base.py
@@ -64,9 +64,11 @@ class PEP621DependencyGetter(DependencyGetter):
         if self._project_uses_setuptools(pyproject_data) and "dependencies" in pyproject_data["project"].get(
             "dynamic", {}
         ):
-            return get_dependencies_from_requirements_files(
-                pyproject_data["tool"]["setuptools"]["dynamic"]["dependencies"]["file"], self.package_module_name_map
-            )
+            dependencies_files = pyproject_data["tool"]["setuptools"]["dynamic"]["dependencies"]["file"]
+            if isinstance(dependencies_files, str):
+                dependencies_files = [dependencies_files]
+
+            return get_dependencies_from_requirements_files(dependencies_files, self.package_module_name_map)
 
         dependency_strings: list[str] = pyproject_data["project"].get("dependencies", [])
         return self._extract_pep_508_dependencies(dependency_strings)
@@ -79,7 +81,10 @@ class PEP621DependencyGetter(DependencyGetter):
             "dynamic", {}
         ):
             return {
-                group: get_dependencies_from_requirements_files(specification["file"], self.package_module_name_map)
+                group: get_dependencies_from_requirements_files(
+                    [specification["file"]] if isinstance(specification["file"], str) else specification["file"],
+                    self.package_module_name_map,
+                )
                 for group, specification in pyproject_data["tool"]["setuptools"]["dynamic"]
                 .get("optional-dependencies", {})
                 .items()

--- a/tests/fixtures/project_with_setuptools_dynamic_dependencies/pyproject.toml
+++ b/tests/fixtures/project_with_setuptools_dynamic_dependencies/pyproject.toml
@@ -12,7 +12,8 @@ dynamic = ["dependencies", "optional-dependencies"]
 dependencies = { file = ["requirements.txt", "requirements-2.txt"] }
 
 [tool.setuptools.dynamic.optional-dependencies]
-cli = { file = ["cli-requirements.txt"] }
+# Both strings and list of strings are accepted.
+cli = { file = "cli-requirements.txt" }
 dev = { file = ["dev-requirements.txt"] }
 
 [tool.deptry]

--- a/tests/unit/dependency_getter/test_pep_621.py
+++ b/tests/unit/dependency_getter/test_pep_621.py
@@ -203,7 +203,8 @@ dynamic = ["dependencies", "optional-dependencies"]
 dependencies = { file = ["requirements.txt", "requirements-2.txt"] }
 
 [tool.setuptools.dynamic.optional-dependencies]
-cli = { file = ["cli-requirements.txt"] }
+# Both strings and list of strings are accepted.
+cli = { file = "cli-requirements.txt" }
 dev = { file = ["dev-requirements.txt"] }
 """
 
@@ -245,7 +246,8 @@ dynamic = ["dependencies", "optional-dependencies"]
 dependencies = { file = ["requirements.txt", "requirements-2.txt"] }
 
 [tool.setuptools.dynamic.optional-dependencies]
-cli = { file = ["cli-requirements.txt"] }
+# Both strings and list of strings are accepted.
+cli = { file = "cli-requirements.txt" }
 dev = { file = ["dev-requirements.txt"] }
 """
 
@@ -286,7 +288,8 @@ dynamic = ["dependencies", "optional-dependencies"]
 dependencies = { file = ["requirements.txt", "requirements-2.txt"] }
 
 [tool.setuptools.dynamic.optional-dependencies]
-cli = { file = ["cli-requirements.txt"] }
+# Both strings and list of strings are accepted.
+cli = { file = "cli-requirements.txt" }
 dev = { file = ["dev-requirements.txt"] }
 """
 
@@ -344,3 +347,34 @@ dev = { file = ["dev-requirements.txt"] }
 
         assert dependencies[0].name == "foo"
         assert dev_dependencies[0].name == "dev-dep"
+
+
+def test_dependency_getter_with_setuptools_dynamic_dependencies_only_dependencies(tmp_path: Path) -> None:
+    fake_pyproject_toml = """[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "foo"
+dependencies = ["foo==1.2.3"]
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = "requirements.txt" }
+"""
+
+    with run_within_dir(tmp_path):
+        with Path("pyproject.toml").open("w") as f:
+            f.write(fake_pyproject_toml)
+
+        with Path("requirements.txt").open("w") as f:
+            f.write("foo==1.2.3")
+
+        extract = PEP621DependencyGetter(config=Path("pyproject.toml"), pep621_dev_dependency_groups=("dev",)).get()
+        dependencies = extract.dependencies
+        dev_dependencies = extract.dev_dependencies
+
+        assert len(dependencies) == 1
+        assert len(dev_dependencies) == 0
+
+        assert dependencies[0].name == "foo"


### PR DESCRIPTION
Closes #944.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

It might not be obvious from [`setuptools` documentation](https://setuptools.pypa.io/en/stable/userguide/pyproject_config.html#dynamic-metadata), but `file` attribute can either be a string or a list of strings.