### PR TITLE
chore(deps): bump Rust to 1.83

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82"
+channel = "1.83"


### PR DESCRIPTION
Release notes: https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html.