### PR TITLE
ci: publish `musl` wheels for Linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
+        manylinux: [auto, musllinux_1_1]
         python: ['3.13', 'pypy3.10']
     steps:
       - name: Check out
@@ -63,14 +64,14 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
+          manylinux: ${{ matrix.manylinux }}
           args: --release --out dist --interpreter ${{ startsWith(matrix.python, 'pypy') && matrix.python || format('python{0}', matrix.python) }}
           sccache: 'true'
-          manylinux: auto
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-linux-${{ matrix.target }}-${{ matrix.python }}
+          name: wheels-linux-${{ matrix.target }}-${{ matrix.manylinux }}-${{ matrix.python }}
           path: dist
 
   windows:


### PR DESCRIPTION
Closes https://github.com/fpgmaas/deptry/issues/977.

**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Publish wheels for `musl` so that users on `alpine` can use the library without building from source.

I was able to test this on `aarch64` with macOS ARM by [running a dry-run release](https://github.com/fpgmaas/deptry/actions/runs/12419884904), then extracting the wheel into a Docker container using `python:alpine`:

```console
$ unzip wheels-linux-aarch64-musllinux_1_1-3.13.zip \
    && docker run --workdir /app --volume .:/app python:3.9-alpine \
    sh -c 'pip install deptry-0.0.1-cp39-abi3-musllinux_1_1_aarch64.whl && deptry .'
[...]
Found 70 dependency issues.

For more information, see the documentation: https://deptry.com/
```

 I don't have access to an `x64` system right now, but I trust that it should also work just fine.