### PR TITLE
docs(changelog): add 0.21.2 release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,8 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
+          # Recent versions (last one tested 1.7.8) lead to failures on Windows aarch64, so forcing the version for now.
+          maturin-version: '1.7.4'
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter ${{ steps.setup-python.outputs.python-path }}
           sccache: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.21.2 - 2024-12-19
+
+### Miscellaneous
+
+* Provide wheels for musllinux ([#979](https://github.com/fpgmaas/deptry/pull/979))
+
+### Full Changelog
+
+https://github.com/fpgmaas/deptry/compare/0.21.1...0.21.2
+
+
 ## 0.21.1 - 2024-11-15
 
 ### Bug Fixes


### PR DESCRIPTION
Release notes for 0.21.2.

Pinning `maturin` to a specific version for now as the release pipeline currently [fails](https://github.com/fpgmaas/deptry/actions/runs/12419884904/job/34676219092) for Windows aarch64 on more recent versions.