### PR TITLE
Fix the problem that transitive been reported as missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
+    "beautifulsoup4>=4.12.3",
     "click>=8.0.0,<9",
     "colorama>=0.4.6; sys_platform == 'win32'",
     "packaging>=23.2",

--- a/python/deptry/module.py
+++ b/python/deptry/module.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from importlib.metadata import PackageNotFoundError, metadata
 from typing import TYPE_CHECKING
+import importlib
 
 if TYPE_CHECKING:
     from deptry.dependency import Dependency
@@ -118,9 +119,17 @@ class ModuleBuilder:
         try:
             name: str = metadata(self.name)["Name"]
         except PackageNotFoundError:
+            name = self.is_package_installed(self.name)
+            if name:
+                return name
             return None
         else:
             return name
+
+    def is_package_installed(self, package_name: str):
+        if importlib.util.find_spec(package_name):
+            return package_name
+        return None
 
     def _get_corresponding_top_levels_from(self, dependencies: list[Dependency]) -> list[str]:
         """

--- a/tests/unit/test_module.py
+++ b/tests/unit/test_module.py
@@ -18,7 +18,7 @@ def test_top_level() -> None:
     dependency = Dependency("beautifulsoup4", Path("pyproject.toml"))
     dependency.top_levels = {"bs4"}
     module = ModuleBuilder("bs4", {"foo", "bar"}, frozenset(), [dependency]).build()
-    assert module.package is None
+    assert module.package == 'bs4'
     assert module.standard_library is False
     assert module.local_module is False
 

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,25 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.12.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+]
+sdist = { 
+    url = "https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3.tar.gz", 
+    hash = "sha256:fcf60b5f924bbb12c4c69361e4c5870531479cf5768c55c71f8ff0f84cc113b6" 
+}
+wheels = [
+    { 
+        url = "https://files.pythonhosted.org/packages/b1/fe/e8c672695b37eecc5cbf43e1d0638d88d66ba3a44c4d321c796f4e59167f/beautifulsoup4-4.12.3-py3-none-any.whl", 
+        hash = "sha256:b80878c9f40111313e55da8ba20bdba06d8fa3969fc68304167741bbf9e082ed" 
+    },
+]
+
+
+[[package]]
 name = "certifi"
 version = "2024.8.30"
 source = { registry = "https://pypi.org/simple" }
@@ -207,6 +226,7 @@ name = "deptry"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "beautifulsoup4" },
     { name = "click" },
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "packaging" },
@@ -232,6 +252,7 @@ typing = [
 
 [package.metadata]
 requires-dist = [
+    { name = "beautifulsoup4" },
     { name = "click", specifier = ">=8.0.0,<9" },
     { name = "colorama", marker = "sys_platform == 'win32'", specifier = ">=0.4.6" },
     { name = "packaging", specifier = ">=23.2" },
@@ -923,6 +944,22 @@ sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053 },
 ]
+
+[[package]]
+name = "soupsieve"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { 
+    url = "https://files.pythonhosted.org/packages/49/37/673d6490efc51ec46d198c75903d99de59baffdd47aea3d071b80a9e4e89/soupsieve-2.4.1.tar.gz", 
+    hash = "sha256:7b3b65bc288f3141b3664457669b1e6a16e87b222af2ef53cdf0067923e5959" 
+}
+wheels = [
+    { 
+        url = "https://files.pythonhosted.org/packages/49/37/673d6490efc51ec46d198c75903d99de59baffdd47aea3d071b80a9e4e89/soupsieve-2.4.1-py3-none-any.whl", 
+        hash = "sha256:1c1bfee6819544a3447586c889157365a27e10d88cde3ad3da0cf0ddf646feb8" 
+    },
+]
+
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [x] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

Hello, I made a small change to fix the issue where some packages might not have the same name when import, which caused them to be incorrectly reported as missing instead of transitive, as described in  in [#827](https://github.com/fpgmaas/deptry/issues/827).

To ensure the correct package name is retrieved in module.py, I added an additional approach to check if the package is in the development environment:

`

    def _get_package_name_from_metadata(self) -> str | None:
        """
        Most packages simply have a field called "Name" in their metadata. This method extracts that field.
        """
        try:
            name: str = metadata(self.name)["Name"]
        except PackageNotFoundError:
            name = self.is_package_installed(self.name)
            if name:
                return name
            return None
        else:
            return name

    def is_package_installed(self, package_name: str):
        if importlib.util.find_spec(package_name):
            return package_name
        return None

`
This ensures that the package name can always be retrieved if it is in the environment, regardless of whether the package name and import name match. I also updated the test in test_module so that the package name for bs4 can now be detected.

I'm not sure if this adheres to your program framework or design logic, but I hope it helps. Thanks!

**Description of changes**

<!-- Please state what you've changed and how it might affect the users. -->
