### PR TITLE
ci: set permissions when publishing docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,8 +191,6 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     steps:
       - uses: actions/download-artifact@v4
-        with:
-          persist-credentials: false
 
       - name: Install Python
         uses: actions/setup-python@v5
@@ -207,9 +205,11 @@ jobs:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*
 
-  check-docs:
+  publish-docs:
     runs-on: ubuntu-24.04
     needs: publish
+    permissions:
+      contents: write
     if: ${{ github.event_name == 'release' }}
     steps:
       - name: Check out


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Documentation publishing is [broken](https://github.com/fpgmaas/deptry/actions/runs/12422008903/job/34683187227). Reproduced on a dummy repository, where setting up permissions to allow writing contents fixed the issue.