### PR TITLE
Revert "ci: pin `maturin` to 1.7.4 for windows release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,8 +105,6 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          # Recent versions (last one tested 1.7.8) lead to failures on Windows aarch64, so forcing the version for now.
-          maturin-version: '1.7.4'
           target: ${{ matrix.target }}
           args: --release --out dist --interpreter ${{ steps.setup-python.outputs.python-path }}
           sccache: 'true'


### PR DESCRIPTION
This reverts commit 1e056278e03d1836b600535b406b51733aae3e8a.