### PR TITLE
chore: fix docs publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,6 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  artipacked:
+    ignore:
+      # Required for publishing documentation to `gh-pages` branch.
+      - release.yml:215


### PR DESCRIPTION
Credentials here are needed to push to `gh-pages` branch.

This will fix https://github.com/fpgmaas/deptry/actions/runs/12422008903/job/34683187227.