### PR TITLE
perf(dependency_getter): search for uv before PDM

### DIFF
--- a/python/deptry/dependency_getter/builder.py
+++ b/python/deptry/dependency_getter/builder.py
@@ -23,12 +23,12 @@ if TYPE_CHECKING:
 @dataclass
 class DependencyGetterBuilder:
     """
-    Class to detect how dependencies are specified:
-    - Either find a pyproject.toml with a [poetry.tool.dependencies] section
-    - Otherwise, find a pyproject.toml with a [tool.pdm] section
-    - Otherwise, find a pyproject.toml with a [tool.uv.dev-dependencies] section
-    - Otherwise, find a pyproject.toml with a [project] section
-    - Otherwise, find a requirements.txt.
+    Class to detect how dependencies are specified, in this specific order:
+    - pyproject.toml found, with a [tool.poetry] section
+    - pyproject.toml found, with a [tool.uv.dev-dependencies] section
+    - pyproject.toml found, with a [tool.pdm.dev-dependencies] section
+    - pyproject.toml found, with a [project] section
+    - requirements.txt found
     """
 
     config: Path
@@ -47,11 +47,11 @@ class DependencyGetterBuilder:
             if self._project_uses_poetry(pyproject_toml):
                 return PoetryDependencyGetter(self.config, self.package_module_name_map)
 
-            if self._project_uses_pdm(pyproject_toml):
-                return PDMDependencyGetter(self.config, self.package_module_name_map, self.pep621_dev_dependency_groups)
-
             if self._project_uses_uv(pyproject_toml):
                 return UvDependencyGetter(self.config, self.package_module_name_map, self.pep621_dev_dependency_groups)
+
+            if self._project_uses_pdm(pyproject_toml):
+                return PDMDependencyGetter(self.config, self.package_module_name_map, self.pep621_dev_dependency_groups)
 
             if self._project_uses_pep_621(pyproject_toml):
                 return PEP621DependencyGetter(

--- a/tests/unit/dependency_getter/test_builder.py
+++ b/tests/unit/dependency_getter/test_builder.py
@@ -174,11 +174,11 @@ def test_dependency_specification_not_found_raises_exception(tmp_path: Path, cap
             " project's dependencies."
         ),
         (
-            "pyproject.toml does not contain a [tool.pdm.dev-dependencies] section, so PDM is not used to specify the"
+            "pyproject.toml does not contain a [tool.uv.dev-dependencies] section, so uv is not used to specify the"
             " project's dependencies."
         ),
         (
-            "pyproject.toml does not contain a [tool.uv.dev-dependencies] section, so uv is not used to specify the"
+            "pyproject.toml does not contain a [tool.pdm.dev-dependencies] section, so PDM is not used to specify the"
             " project's dependencies."
         ),
         (


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

Tiny performance improvement. Searching for uv before PDM makes sense IMO, as I believe more projects use uv than PDM now.