### PR TITLE
chore: bump rust to 1.84

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83"
+channel = "1.84"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html