### PR TITLE
chore: bump rust to 1.86

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85"
+channel = "1.86"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html