### PR TITLE
chore: bump rust to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "deptryrs"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.87"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"


### PR DESCRIPTION
https://blog.rust-lang.org/2025/05/15/Rust-1.87.0/