### PR TITLE
chore(renovate): pin GitHub actions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,6 +20,9 @@
 
     // https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions
     "customManagers:githubActionsVersions",
+
+    // https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigests
+    "helpers:pinGitHubActionDigests",
   ],
 
   // https://docs.renovatebot.com/configuration-options/#ignorepresets


### PR DESCRIPTION
This is considered [a good practice](https://docs.renovatebot.com/upgrade-best-practices/#extends-helperspingithubactiondigests), and is even [reported by zizmor](https://docs.zizmor.sh/audits/#unpinned-uses).