### PR TITLE
feat: build wheels for PyPy 3.11 and drop 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
           - '3.12'
           - '3.13'
           - '3.14-dev'
-          - 'pypy3.10'
+          - 'pypy3.11'
       fail-fast: false
     runs-on: ${{ matrix.os.image }}
     name: ${{ matrix.os.name }} (${{ matrix.python-version }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         target: [x86_64, aarch64]
         manylinux: [auto, musllinux_1_1]
-        python: ['3.13', 'pypy3.10']
+        python: ['3.13', 'pypy3.11']
     steps:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         target: [x64]
-        python: ['3.13', 'pypy3.10']
+        python: ['3.13', 'pypy3.11']
         # PyPy doesn't support Windows ARM64.
         include:
           - python: '3.13'
@@ -120,7 +120,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python: ['3.13', 'pypy3.10']
+        python: ['3.13', 'pypy3.11']
     steps:
       - name: Check out
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,11 @@ DEP001 = ["tomllib"]
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
-filterwarnings = ["error"]
+filterwarnings = [
+    "error",
+    # Triggered by PyPy 3.11 on Windows.
+    "default:check_home argument is deprecated and ignored:DeprecationWarning",
+]
 norecursedirs = ["fixtures*"]
 
 [tool.ruff]


### PR DESCRIPTION
**PR Checklist**

- [x] A description of the changes is added to the description of this PR.
- [ ] If there is a related issue, make sure it is linked to this PR.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added or modified a feature, documentation in `docs` is updated

**Description of changes**

PyPy 3.10 is [not supported anymore](https://pypy.org/posts/2025/07/pypy-v7320-release.html), only 3.11 is.