### PR TITLE
add readme to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{ name = "Florian Maas", email = "fpgmaas@gmail.com" }]
 maintainers = [{ name = "Mathieu Kniewallner", email = "mathieu.kniewallner@gmail.com" }]
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
+readme = "README.md"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",


### PR DESCRIPTION
**Description of changes**

Seems like `readme` field is missing, causing the [PyPI page](https://pypi.org/project/deptry/) to display

> The author of this package has not provided a project description

This PR proposes to fix that.